### PR TITLE
Remove default ShouldSkip implementation

### DIFF
--- a/src/search/queries/distance_feature_query.rs
+++ b/src/search/queries/distance_feature_query.rs
@@ -226,11 +226,7 @@ impl<O: Origin> DistanceFeatureQuery<O> {
     add_boost_and_name!();
 }
 
-impl<O: Origin> ShouldSkip for DistanceFeatureQuery<O> {
-    fn should_skip(&self) -> bool {
-        false
-    }
-}
+impl<O: Origin> ShouldSkip for DistanceFeatureQuery<O> {}
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/exists_query.rs
+++ b/src/search/queries/exists_query.rs
@@ -79,11 +79,7 @@ impl ExistsQuery {
     add_boost_and_name!();
 }
 
-impl ShouldSkip for ExistsQuery {
-    fn should_skip(&self) -> bool {
-        false
-    }
-}
+impl ShouldSkip for ExistsQuery {}
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/match_all_query.rs
+++ b/src/search/queries/match_all_query.rs
@@ -55,11 +55,7 @@ impl MatchAllQuery {
     add_boost_and_name!();
 }
 
-impl ShouldSkip for MatchAllQuery {
-    fn should_skip(&self) -> bool {
-        false
-    }
-}
+impl ShouldSkip for MatchAllQuery {}
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/match_none_query.rs
+++ b/src/search/queries/match_none_query.rs
@@ -55,11 +55,7 @@ impl MatchNoneQuery {
     add_boost_and_name!();
 }
 
-impl ShouldSkip for MatchNoneQuery {
-    fn should_skip(&self) -> bool {
-        false
-    }
-}
+impl ShouldSkip for MatchNoneQuery {}
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/percolate_query.rs
+++ b/src/search/queries/percolate_query.rs
@@ -124,11 +124,7 @@ impl<T: PercolateMarker> PercolateQuery<T> {
     }
 }
 
-impl<T: PercolateMarker> ShouldSkip for PercolateQuery<T> {
-    fn should_skip(&self) -> bool {
-        false
-    }
-}
+impl<T: PercolateMarker> ShouldSkip for PercolateQuery<T> {}
 
 impl PercolateQuery<PercolateLookup> {
     /// Creates an instance of [PercolateQuery](PercolateQuery)

--- a/src/search/queries/terms_query.rs
+++ b/src/search/queries/terms_query.rs
@@ -196,11 +196,7 @@ impl ShouldSkip for TermsQuery<BTreeSet<Scalar>> {
     }
 }
 
-impl ShouldSkip for TermsQuery<TermsLookup> {
-    fn should_skip(&self) -> bool {
-        false
-    }
-}
+impl ShouldSkip for TermsQuery<TermsLookup> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
It's `false` by default, no need to reimplement it.