### PR TITLE
Remove debug query and aggregtion macros

### DIFF
--- a/src/search/aggregations/mod.rs
+++ b/src/search/aggregations/mod.rs
@@ -21,7 +21,6 @@ pub use self::bucket::*;
 pub use self::metrics::*;
 pub use self::pipeline::*;
 
-#[cfg(not(debug_assertions))]
 macro_rules! aggregation {
     ($name:ident { $($variant:ident($query:ty)),+ $(,)? }) => {
         /// A container enum for supported Elasticsearch query types
@@ -38,40 +37,6 @@ macro_rules! aggregation {
             impl From<$query> for $name {
                 fn from(q: $query) -> Self {
                     $name::$variant(q)
-                }
-            }
-        )+
-
-        impl $name {
-            /// Gets aggregation name
-            pub fn name(&self) -> String {
-                match self {
-                    $(
-                        Self::$variant(a) => a.name.clone(),
-                    )+
-                }
-            }
-        }
-    };
-}
-
-#[cfg(debug_assertions)]
-macro_rules! aggregation {
-    ($name:ident { $($variant:ident($query:ty)),+ $(,)? }) => {
-        /// A container enum for supported Elasticsearch query types
-        #[derive(Debug, Clone, PartialEq, Serialize)]
-        #[serde(untagged)]
-        #[allow(missing_docs)]
-        pub enum $name {
-            $(
-                $variant(Box<$query>),
-            )*
-        }
-
-        $(
-            impl From<$query> for $name {
-                fn from(q: $query) -> Self {
-                    $name::$variant(Box::new(q))
                 }
             }
         )+

--- a/src/search/queries/mod.rs
+++ b/src/search/queries/mod.rs
@@ -42,7 +42,6 @@ pub use self::match_none_query::*;
 
 use crate::util::*;
 
-#[cfg(not(debug_assertions))]
 macro_rules! query {
     ($name:ident { $($variant:ident($query:ty)),+ $(,)? }) => {
         /// A container enum for supported Elasticsearch query types
@@ -70,51 +69,6 @@ macro_rules! query {
                         None
                     } else {
                         Some($name::$variant(q))
-                    }
-                }
-            }
-        )+
-
-        impl ShouldSkip for $name {
-            fn should_skip(&self) -> bool {
-                match self {
-                    $(
-                        $name::$variant(q) => q.should_skip(),
-                    )+
-                }
-            }
-        }
-    };
-}
-
-#[cfg(debug_assertions)]
-macro_rules! query {
-    ($name:ident { $($variant:ident($query:ty)),+ $(,)? }) => {
-        /// A container enum for supported Elasticsearch query types
-        #[derive(Debug, Clone, PartialEq, Serialize)]
-        #[serde(untagged)]
-        #[allow(missing_docs)]
-        pub enum $name {
-            $(
-                $variant(Box<$query>),
-            )*
-        }
-
-        $(
-            impl From<$query> for $name {
-                fn from(q: $query) -> Self {
-                    $name::$variant(Box::new(q))
-                }
-            }
-        )+
-
-        $(
-            impl From<$query> for Option<$name> {
-                fn from(q: $query) -> Self {
-                    if q.should_skip() {
-                        None
-                    } else {
-                        Some($name::$variant(Box::new(q)))
                     }
                 }
             }


### PR DESCRIPTION
These were internal attempts to optimize queries and should not be part of public API.