### PR TITLE
Refactor boost implementation

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -37,8 +37,10 @@ macro_rules! add_boost_and_name {
         /// Boost values are relative to the default value of `1.0`.
         /// A boost value between 0 and `1.0` decreases the relevance score.
         /// A value greater than `1.0` increases the relevance score.
-        pub fn boost(mut self, boost: impl Into<Boost>) -> Self {
-            self.inner.boost = Some(boost.into());
+        pub fn boost(mut self, boost: impl std::convert::TryInto<Boost>) -> Self {
+            if let Ok(boost) = boost.try_into() {
+                self.inner.boost = Some(boost);
+            }
             self
         }
 

--- a/src/search/queries/compound/boosting_query.rs
+++ b/src/search/queries/compound/boosting_query.rs
@@ -126,7 +126,7 @@ mod tests {
                         }
                     },
                     "negative_boost": 0.2,
-                    "boost": 3.0,
+                    "boost": 3,
                     "_name": "test"
                 }
             })

--- a/src/search/queries/compound/constant_score_query.rs
+++ b/src/search/queries/compound/constant_score_query.rs
@@ -93,7 +93,7 @@ mod tests {
                             }
                         }
                     },
-                    "boost": 3.0,
+                    "boost": 3,
                     "_name": "test"
                 }
             })

--- a/src/search/queries/compound/dis_max_query.rs
+++ b/src/search/queries/compound/dis_max_query.rs
@@ -199,7 +199,7 @@ mod tests {
                         }
                     ],
                     "tie_breaker": 0.5,
-                    "boost": 3.0,
+                    "boost": 3,
                     "_name": "test"
                 }
             })

--- a/src/search/queries/compound/function_score_query.rs
+++ b/src/search/queries/compound/function_score_query.rs
@@ -88,8 +88,10 @@ impl FunctionScoreQuery {
     }
 
     /// Maximum score value after applying all the functions
-    pub fn max_boost(mut self, max_boost: impl Into<Boost>) -> Self {
-        self.inner.max_boost = Some(max_boost.into());
+    pub fn max_boost(mut self, max_boost: impl std::convert::TryInto<Boost>) -> Self {
+        if let Ok(max_boost) = max_boost.try_into() {
+            self.inner.max_boost = Some(max_boost);
+        }
         self
     }
 

--- a/src/search/queries/full_text/combined_fields_query.rs
+++ b/src/search/queries/full_text/combined_fields_query.rs
@@ -159,7 +159,7 @@ mod tests {
                     "operator": "AND",
                     "minimum_should_match": "22",
                     "zero_terms_query": "none",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "test",
                 }
             })

--- a/src/search/queries/full_text/match_bool_prefix_query.rs
+++ b/src/search/queries/full_text/match_bool_prefix_query.rs
@@ -147,7 +147,7 @@ mod tests {
                         "analyzer": "search_time_analyzer",
                         "minimum_should_match": "12",
                         "operator": "OR",
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test"
                     }
                 }

--- a/src/search/queries/full_text/match_phrase_prefix_query.rs
+++ b/src/search/queries/full_text/match_phrase_prefix_query.rs
@@ -158,7 +158,7 @@ mod tests {
                         "max_expansions": 20,
                         "slop": 5,
                         "zero_terms_query": "none",
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test"
                     }
                 }

--- a/src/search/queries/full_text/match_phrase_query.rs
+++ b/src/search/queries/full_text/match_phrase_query.rs
@@ -132,7 +132,7 @@ mod tests {
                         "query": "search text",
                         "analyzer": "search_time_analyzer",
                         "slop": 1,
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test"
                     }
                 }

--- a/src/search/queries/full_text/match_query.rs
+++ b/src/search/queries/full_text/match_query.rs
@@ -273,7 +273,7 @@ mod tests {
                         "operator": "AND",
                         "minimum_should_match": "22",
                         "zero_terms_query": "none",
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test"
                     }
                 }

--- a/src/search/queries/full_text/multi_match_query.rs
+++ b/src/search/queries/full_text/multi_match_query.rs
@@ -287,7 +287,7 @@ mod tests {
                     "operator": "AND",
                     "minimum_should_match": "22",
                     "zero_terms_query": "none",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "test",
                 }
             })

--- a/src/search/queries/full_text/query_string_query.rs
+++ b/src/search/queries/full_text/query_string_query.rs
@@ -422,7 +422,7 @@ mod tests {
                     "lenient": true,
                     "minimum_should_match": "22",
                     "quote_field_suffix": "s",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "test",
                 }
             })

--- a/src/search/queries/full_text/simple_query_string_query.rs
+++ b/src/search/queries/full_text/simple_query_string_query.rs
@@ -295,7 +295,7 @@ mod tests {
                     "lenient": true,
                     "minimum_should_match": "22",
                     "quote_field_suffix": "s",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "test",
                 }
             })

--- a/src/search/queries/joining/has_child_query.rs
+++ b/src/search/queries/joining/has_child_query.rs
@@ -151,7 +151,7 @@ mod tests {
                             }
                         }
                     },
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "test"
                 }
             })

--- a/src/search/queries/joining/has_parent_query.rs
+++ b/src/search/queries/joining/has_parent_query.rs
@@ -131,7 +131,7 @@ mod tests {
                             }
                         }
                     },
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "test"
                 }
             })

--- a/src/search/queries/joining/nested_query.rs
+++ b/src/search/queries/joining/nested_query.rs
@@ -173,7 +173,7 @@ mod tests {
                             }
                         }
                     },
-                    "boost": 3.0,
+                    "boost": 3,
                     "_name": "test",
                 }
             })

--- a/src/search/queries/joining/parent_id_query.rs
+++ b/src/search/queries/joining/parent_id_query.rs
@@ -96,7 +96,7 @@ mod tests {
                     "type": "my-child",
                     "id": "1",
                     "ignore_unmapped": true,
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "test"
                 }
             })

--- a/src/search/queries/match_all_query.rs
+++ b/src/search/queries/match_all_query.rs
@@ -52,7 +52,7 @@ mod tests {
 
         with_all_fields(
             Query::match_all().boost(2).name("test"),
-            json!({ "match_all": { "boost": 2.0, "_name": "test" } })
+            json!({ "match_all": { "boost": 2, "_name": "test" } })
         );
     }
 }

--- a/src/search/queries/match_none_query.rs
+++ b/src/search/queries/match_none_query.rs
@@ -52,7 +52,7 @@ mod tests {
 
         with_all_fields(
             Query::match_none().boost(2).name("test"),
-            json!({ "match_none": { "boost": 2.0, "_name": "test" } })
+            json!({ "match_none": { "boost": 2, "_name": "test" } })
         );
     }
 }

--- a/src/search/queries/params/boost.rs
+++ b/src/search/queries/params/boost.rs
@@ -1,56 +1,367 @@
 //! A container type for boost values
 
-use std::{cmp::Ordering, f32, fmt};
+use std::{cmp::Ordering, convert::TryFrom, fmt};
+
+const ERROR_MSG: &str = "Boost value cannot be negative";
 
 /// A container type for boost values
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize)]
-pub struct Boost(f32);
+pub struct Boost(Inner);
 
 impl fmt::Display for Boost {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Inner::U64(value) => value.fmt(f),
+            Inner::F32(value) => value.fmt(f),
+            Inner::F64(value) => value.fmt(f),
+        }
     }
 }
 
-impl Boost {
-    /// Minimum boost value
-    const MINIMUM: f32 = 0f32;
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize)]
+#[serde(untagged)]
+enum Inner {
+    U64(u64),
+    F32(f32),
+    F64(f64),
+}
 
-    /// Creates a new instance of boost value
-    ///
-    /// Constraints boost to non-negative values only
-    pub fn new(boost: f32) -> Self {
-        let boost = f32::max(Self::MINIMUM, boost);
+// i8
 
-        Self(boost)
+impl TryFrom<i8> for Boost {
+    type Error = &'static str;
+
+    fn try_from(value: i8) -> Result<Self, Self::Error> {
+        if value < 0 {
+            Err(ERROR_MSG)
+        } else {
+            Ok(Self(Inner::U64(value as u64)))
+        }
     }
 }
 
-impl From<f32> for Boost {
-    fn from(boost: f32) -> Self {
-        Self::new(boost)
+impl PartialEq<i8> for Boost {
+    fn eq(&self, other: &i8) -> bool {
+        match self.0 {
+            Inner::U64(value) => value.eq(&(*other as u64)),
+            Inner::F32(value) => value.eq(&(*other as f32)),
+            Inner::F64(value) => value.eq(&(*other as f64)),
+        }
     }
 }
 
-impl From<i32> for Boost {
-    fn from(boost: i32) -> Self {
-        Self::new(boost as f32)
+impl PartialOrd<i8> for Boost {
+    fn partial_cmp(&self, other: &i8) -> Option<Ordering> {
+        match self.0 {
+            Inner::U64(value) => {
+                if other < &0 {
+                    Some(Ordering::Greater)
+                } else {
+                    value.partial_cmp(&(*other as u64))
+                }
+            }
+            Inner::F32(value) => value.partial_cmp(&(*other as f32)),
+            Inner::F64(value) => value.partial_cmp(&(*other as f64)),
+        }
+    }
+}
+
+// i16
+
+impl TryFrom<i16> for Boost {
+    type Error = &'static str;
+
+    fn try_from(value: i16) -> Result<Self, Self::Error> {
+        if value < 0 {
+            Err(ERROR_MSG)
+        } else {
+            Ok(Self(Inner::U64(value as u64)))
+        }
+    }
+}
+
+impl PartialEq<i16> for Boost {
+    fn eq(&self, other: &i16) -> bool {
+        match self.0 {
+            Inner::U64(value) => value.eq(&(*other as u64)),
+            Inner::F32(value) => value.eq(&(*other as f32)),
+            Inner::F64(value) => value.eq(&(*other as f64)),
+        }
+    }
+}
+
+impl PartialOrd<i16> for Boost {
+    fn partial_cmp(&self, other: &i16) -> Option<Ordering> {
+        match self.0 {
+            Inner::U64(value) => {
+                if other < &0 {
+                    Some(Ordering::Greater)
+                } else {
+                    value.partial_cmp(&(*other as u64))
+                }
+            }
+            Inner::F32(value) => value.partial_cmp(&(*other as f32)),
+            Inner::F64(value) => value.partial_cmp(&(*other as f64)),
+        }
+    }
+}
+
+// i32
+
+impl TryFrom<i32> for Boost {
+    type Error = &'static str;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        if value < 0 {
+            Err(ERROR_MSG)
+        } else {
+            Ok(Self(Inner::U64(value as u64)))
+        }
+    }
+}
+
+impl PartialEq<i32> for Boost {
+    fn eq(&self, other: &i32) -> bool {
+        match self.0 {
+            Inner::U64(value) => value.eq(&(*other as u64)),
+            Inner::F32(value) => value.eq(&(*other as f32)),
+            Inner::F64(value) => value.eq(&(*other as f64)),
+        }
+    }
+}
+
+impl PartialOrd<i32> for Boost {
+    fn partial_cmp(&self, other: &i32) -> Option<Ordering> {
+        match self.0 {
+            Inner::U64(value) => {
+                if other < &0 {
+                    Some(Ordering::Greater)
+                } else {
+                    value.partial_cmp(&(*other as u64))
+                }
+            }
+            Inner::F32(value) => value.partial_cmp(&(*other as f32)),
+            Inner::F64(value) => value.partial_cmp(&(*other as f64)),
+        }
+    }
+}
+
+// i64
+
+impl TryFrom<i64> for Boost {
+    type Error = &'static str;
+
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        if value < 0 {
+            Err(ERROR_MSG)
+        } else {
+            Ok(Self(Inner::U64(value as u64)))
+        }
+    }
+}
+
+impl PartialEq<i64> for Boost {
+    fn eq(&self, other: &i64) -> bool {
+        match self.0 {
+            Inner::U64(value) => value.eq(&(*other as u64)),
+            Inner::F32(value) => value.eq(&(*other as f32)),
+            Inner::F64(value) => value.eq(&(*other as f64)),
+        }
+    }
+}
+
+impl PartialOrd<i64> for Boost {
+    fn partial_cmp(&self, other: &i64) -> Option<Ordering> {
+        match self.0 {
+            Inner::U64(value) => {
+                if other < &0 {
+                    Some(Ordering::Greater)
+                } else {
+                    value.partial_cmp(&(*other as u64))
+                }
+            }
+            Inner::F32(value) => value.partial_cmp(&(*other as f32)),
+            Inner::F64(value) => value.partial_cmp(&(*other as f64)),
+        }
+    }
+}
+
+// u8
+
+impl From<u8> for Boost {
+    fn from(value: u8) -> Self {
+        Self(Inner::U64(value as u64))
+    }
+}
+
+impl PartialEq<u8> for Boost {
+    fn eq(&self, other: &u8) -> bool {
+        match self.0 {
+            Inner::U64(value) => value.eq(&(*other as u64)),
+            Inner::F32(value) => value.eq(&(*other as f32)),
+            Inner::F64(value) => value.eq(&(*other as f64)),
+        }
+    }
+}
+
+impl PartialOrd<u8> for Boost {
+    fn partial_cmp(&self, other: &u8) -> Option<Ordering> {
+        match self.0 {
+            Inner::U64(value) => value.partial_cmp(&(*other as u64)),
+            Inner::F32(value) => value.partial_cmp(&(*other as f32)),
+            Inner::F64(value) => value.partial_cmp(&(*other as f64)),
+        }
+    }
+}
+
+// u16
+
+impl From<u16> for Boost {
+    fn from(value: u16) -> Self {
+        Self(Inner::U64(value as u64))
+    }
+}
+
+impl PartialEq<u16> for Boost {
+    fn eq(&self, other: &u16) -> bool {
+        match self.0 {
+            Inner::U64(value) => value.eq(&(*other as u64)),
+            Inner::F32(value) => value.eq(&(*other as f32)),
+            Inner::F64(value) => value.eq(&(*other as f64)),
+        }
+    }
+}
+
+impl PartialOrd<u16> for Boost {
+    fn partial_cmp(&self, other: &u16) -> Option<Ordering> {
+        match self.0 {
+            Inner::U64(value) => value.partial_cmp(&(*other as u64)),
+            Inner::F32(value) => value.partial_cmp(&(*other as f32)),
+            Inner::F64(value) => value.partial_cmp(&(*other as f64)),
+        }
+    }
+}
+
+// u32
+
+impl From<u32> for Boost {
+    fn from(value: u32) -> Self {
+        Self(Inner::U64(value as u64))
+    }
+}
+
+impl PartialEq<u32> for Boost {
+    fn eq(&self, other: &u32) -> bool {
+        match self.0 {
+            Inner::U64(value) => value.eq(&(*other as u64)),
+            Inner::F32(value) => value.eq(&(*other as f32)),
+            Inner::F64(value) => value.eq(&(*other as f64)),
+        }
+    }
+}
+
+impl PartialOrd<u32> for Boost {
+    fn partial_cmp(&self, other: &u32) -> Option<Ordering> {
+        match self.0 {
+            Inner::U64(value) => value.partial_cmp(&(*other as u64)),
+            Inner::F32(value) => value.partial_cmp(&(*other as f32)),
+            Inner::F64(value) => value.partial_cmp(&(*other as f64)),
+        }
+    }
+}
+
+// u64
+
+impl From<u64> for Boost {
+    fn from(value: u64) -> Self {
+        Self(Inner::U64(value))
+    }
+}
+
+impl PartialEq<u64> for Boost {
+    fn eq(&self, other: &u64) -> bool {
+        match self.0 {
+            Inner::U64(value) => value.eq(other),
+            Inner::F32(value) => value.eq(&(*other as f32)),
+            Inner::F64(value) => value.eq(&(*other as f64)),
+        }
+    }
+}
+
+impl PartialOrd<u64> for Boost {
+    fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+        match self.0 {
+            Inner::U64(value) => value.partial_cmp(other),
+            Inner::F32(value) => value.partial_cmp(&(*other as f32)),
+            Inner::F64(value) => value.partial_cmp(&(*other as f64)),
+        }
+    }
+}
+
+// f32
+
+impl TryFrom<f32> for Boost {
+    type Error = &'static str;
+
+    fn try_from(value: f32) -> Result<Self, Self::Error> {
+        if value < 0. {
+            Err(ERROR_MSG)
+        } else {
+            Ok(Self(Inner::F32(value)))
+        }
     }
 }
 
 impl PartialEq<f32> for Boost {
     fn eq(&self, other: &f32) -> bool {
-        self.0.eq(other)
+        match self.0 {
+            Inner::U64(value) => (value as f32).eq(other),
+            Inner::F32(value) => value.eq(other),
+            Inner::F64(value) => (value as f32).eq(other),
+        }
     }
 }
 
 impl PartialOrd<f32> for Boost {
     fn partial_cmp(&self, other: &f32) -> Option<Ordering> {
-        match (self.0 <= *other, self.0 >= *other) {
-            (false, false) => None,
-            (false, true) => Some(Ordering::Greater),
-            (true, false) => Some(Ordering::Less),
-            (true, true) => Some(Ordering::Equal),
+        match self.0 {
+            Inner::U64(value) => (value as f32).partial_cmp(other),
+            Inner::F32(value) => value.partial_cmp(other),
+            Inner::F64(value) => (value as f32).partial_cmp(other),
+        }
+    }
+}
+
+// f64
+
+impl TryFrom<f64> for Boost {
+    type Error = &'static str;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        if value < 0. {
+            Err(ERROR_MSG)
+        } else {
+            Ok(Self(Inner::F64(value)))
+        }
+    }
+}
+
+impl PartialEq<f64> for Boost {
+    fn eq(&self, other: &f64) -> bool {
+        match self.0 {
+            Inner::U64(value) => (value as f64).eq(other),
+            Inner::F32(value) => value.eq(&(*other as f32)),
+            Inner::F64(value) => value.eq(other),
+        }
+    }
+}
+
+impl PartialOrd<f64> for Boost {
+    fn partial_cmp(&self, other: &f64) -> Option<Ordering> {
+        match self.0 {
+            Inner::U64(value) => (value as f64).partial_cmp(other),
+            Inner::F32(value) => value.partial_cmp(&(*other as f32)),
+            Inner::F64(value) => value.partial_cmp(other),
         }
     }
 }
@@ -61,22 +372,50 @@ mod tests {
 
     #[test]
     fn out_of_bounds() {
-        assert_eq!(Boost::new(-1.0), Boost::new(0.0));
+        assert!(Boost::try_from(-1_i8).is_err());
+        assert!(Boost::try_from(-1_i16).is_err());
+        assert!(Boost::try_from(-1_i32).is_err());
+        assert!(Boost::try_from(-1_i64).is_err());
+        assert!(Boost::try_from(-1_f32).is_err());
+        assert!(Boost::try_from(-1_f64).is_err());
     }
 
     #[test]
     fn within_bounds() {
-        assert_eq!(Boost::new(1.23), Boost::new(1.23));
+        assert!(Boost::try_from(1_i8).unwrap() == 1);
+        assert!(Boost::try_from(1_i16).unwrap() == 1);
+        assert!(Boost::try_from(1_i32).unwrap() == 1);
+        assert!(Boost::try_from(1_i64).unwrap() == 1);
+        assert!(Boost::try_from(1_u8).unwrap() == 1);
+        assert!(Boost::try_from(1_u16).unwrap() == 1);
+        assert!(Boost::try_from(1_u32).unwrap() == 1);
+        assert!(Boost::try_from(1_u64).unwrap() == 1);
+        assert!(Boost::try_from(1_f32).unwrap() == 1);
+        assert!(Boost::try_from(1_f64).unwrap() == 1);
     }
 
     #[test]
-    fn partial_eq_with_floats() {
-        assert_eq!(Boost::new(1.2).partial_cmp(&1.2f32), Some(Ordering::Equal));
-    }
+    fn partial_ord() {
+        assert!(Boost::try_from(2_i8).unwrap() > 1);
+        assert!(Boost::try_from(2_i16).unwrap() > 1);
+        assert!(Boost::try_from(2_i32).unwrap() > 1);
+        assert!(Boost::try_from(2_i64).unwrap() > 1);
+        assert!(Boost::try_from(2_u8).unwrap() > 1);
+        assert!(Boost::try_from(2_u16).unwrap() > 1);
+        assert!(Boost::try_from(2_u32).unwrap() > 1);
+        assert!(Boost::try_from(2_u64).unwrap() > 1);
+        assert!(Boost::try_from(2_f32).unwrap() > 1);
+        assert!(Boost::try_from(2_f64).unwrap() > 1);
 
-    #[test]
-    fn partial_ord_with_floats() {
-        assert!(Boost::new(1.2) <= 1.3f32);
-        assert!(Boost::new(1.2) >= 1.1f32);
+        assert!(Boost::try_from(2_i8).unwrap() > 1.);
+        assert!(Boost::try_from(2_i16).unwrap() > 1.);
+        assert!(Boost::try_from(2_i32).unwrap() > 1.);
+        assert!(Boost::try_from(2_i64).unwrap() > 1.);
+        assert!(Boost::try_from(2_u8).unwrap() > 1.);
+        assert!(Boost::try_from(2_u16).unwrap() > 1.);
+        assert!(Boost::try_from(2_u32).unwrap() > 1.);
+        assert!(Boost::try_from(2_u64).unwrap() > 1.);
+        assert!(Boost::try_from(2_f32).unwrap() > 1.);
+        assert!(Boost::try_from(2_f64).unwrap() > 1.);
     }
 }

--- a/src/search/queries/params/terms_query.rs
+++ b/src/search/queries/params/terms_query.rs
@@ -1,5 +1,5 @@
+use crate::search::*;
 use crate::util::*;
-use crate::Scalar;
 use serde::ser::Serialize;
 use std::{collections::BTreeSet, fmt::Debug};
 

--- a/src/search/queries/specialized/distance_feature_query.rs
+++ b/src/search/queries/specialized/distance_feature_query.rs
@@ -229,7 +229,7 @@ mod tests {
                         "field": "test",
                         "origin": [13.0, 12.0],
                         "pivot": "15km",
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test",
                     }
                 })

--- a/src/search/queries/specialized/rank_feature_query.rs
+++ b/src/search/queries/specialized/rank_feature_query.rs
@@ -384,7 +384,7 @@ mod tests {
             json!({
                 "rank_feature": {
                     "field": "test",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "query",
                 }
             })
@@ -395,7 +395,7 @@ mod tests {
             json!({
                 "rank_feature": {
                     "field": "test",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "query",
                     "saturation": {},
                 }
@@ -407,7 +407,7 @@ mod tests {
             json!({
                 "rank_feature": {
                     "field": "test",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "query",
                     "saturation": {
                         "pivot": 2.2,
@@ -421,7 +421,7 @@ mod tests {
             json!({
                 "rank_feature": {
                     "field": "test",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "query",
                     "log": {
                         "scaling_factor": 2.2
@@ -435,7 +435,7 @@ mod tests {
             json!({
                 "rank_feature": {
                     "field": "test",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "query",
                     "sigmoid": {
                         "pivot": 2.2,
@@ -450,7 +450,7 @@ mod tests {
             json!({
                 "rank_feature": {
                     "field": "test",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "query",
                     "linear": {},
                 }

--- a/src/search/queries/term_level/exists_query.rs
+++ b/src/search/queries/term_level/exists_query.rs
@@ -80,7 +80,7 @@ mod tests {
             json!({
                 "exists": {
                     "field": "test",
-                    "boost": 2.0,
+                    "boost": 2,
                     "_name": "test"
                 }
             })

--- a/src/search/queries/term_level/fuzzy_query.rs
+++ b/src/search/queries/term_level/fuzzy_query.rs
@@ -181,7 +181,7 @@ mod tests {
                         "prefix_length": 4,
                         "transpositions": false,
                         "rewrite": "scoring_boolean",
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test"
                     }
                 }

--- a/src/search/queries/term_level/prefix_query.rs
+++ b/src/search/queries/term_level/prefix_query.rs
@@ -131,7 +131,7 @@ mod tests {
                         "value": 123,
                         "rewrite": "constant_score",
                         "case_insensitive": true,
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test"
                     }
                 }

--- a/src/search/queries/term_level/range_query.rs
+++ b/src/search/queries/term_level/range_query.rs
@@ -208,7 +208,7 @@ mod tests {
                         "lt": 3,
                         "lte": 4,
                         "relation": "WITHIN",
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "range_query_test"
                     }
                 }
@@ -236,7 +236,7 @@ mod tests {
                         "format": "yyyy-MM-dd",
                         "time_zone": "UTC",
                         "relation": "CONTAINS",
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "range_query_test"
                     }
                 }

--- a/src/search/queries/term_level/regexp_query.rs
+++ b/src/search/queries/term_level/regexp_query.rs
@@ -176,7 +176,7 @@ mod tests {
                         "case_insensitive": false,
                         "max_determinized_states": 2,
                         "rewrite": "constant_score",
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test"
                     }
                 }

--- a/src/search/queries/term_level/term_query.rs
+++ b/src/search/queries/term_level/term_query.rs
@@ -104,7 +104,7 @@ mod tests {
                 "term": {
                     "test": {
                         "value": 123,
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test"
                     }
                 }

--- a/src/search/queries/term_level/terms_query.rs
+++ b/src/search/queries/term_level/terms_query.rs
@@ -152,7 +152,7 @@ mod tests {
                 json!({
                     "terms": {
                         "test": [123],
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test",
                     }
                 })
@@ -205,7 +205,7 @@ mod tests {
                             "path": "path_value",
                             "routing": "routing_value"
                         },
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test",
                     }
                 })

--- a/src/search/queries/term_level/terms_set_query.rs
+++ b/src/search/queries/term_level/terms_set_query.rs
@@ -134,7 +134,7 @@ mod tests {
                                 "num_terms_sets": 2
                             }
                         },
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test"
                     }
                 }

--- a/src/search/queries/term_level/wildcard_query.rs
+++ b/src/search/queries/term_level/wildcard_query.rs
@@ -126,7 +126,7 @@ mod tests {
                         "value": "value*",
                         "rewrite": "constant_score",
                         "case_insensitive": true,
-                        "boost": 2.0,
+                        "boost": 2,
                         "_name": "test"
                     }
                 }

--- a/src/search/rescoring/mod.rs
+++ b/src/search/rescoring/mod.rs
@@ -1,8 +1,8 @@
 //! Rescore clause to run second query over original one results and that way give more accuracy for final results
 //! <https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-rescore.html>
 
+use crate::search::*;
 use crate::util::*;
-use crate::Query;
 
 /// Rescoring can help to improve precision by reordering just the top (eg 100 - 500)
 /// documents returned by the [query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#request-body-search-query)


### PR DESCRIPTION
There have been a couple of issues:
- integers casted to floats
- negative values replaced with a 0
- f64 <-> f32 conversion could lose precision and cause incorrect boost values

This changes implementation so that boost now contains an inner enum of u64/f32/f64 to cover all the required cases:
- Integer boost
- f32 and f64 boosts to keep the precision