### PR TITLE
Disable default Chrono features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = ["examples/*"]
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
+serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1" }
 
 [dev-dependencies]


### PR DESCRIPTION
Crate requires serialization only.