### PR TITLE
Add missing geo query conversions to Query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/src/search/queries/geo/geo_bounding_box_query.rs
+++ b/src/search/queries/geo/geo_bounding_box_query.rs
@@ -56,6 +56,12 @@ impl GeoBoundingBoxQuery {
     add_boost_and_name!();
 }
 
+impl ShouldSkip for GeoBoundingBoxQuery {
+    fn should_skip(&self) -> bool {
+        self.inner.pair.key.should_skip()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/search/queries/geo/geo_distance_query.rs
+++ b/src/search/queries/geo/geo_distance_query.rs
@@ -75,6 +75,12 @@ impl GeoDistanceQuery {
     add_boost_and_name!();
 }
 
+impl ShouldSkip for GeoDistanceQuery {
+    fn should_skip(&self) -> bool {
+        self.inner.pair.key.should_skip()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/search/queries/mod.rs
+++ b/src/search/queries/mod.rs
@@ -122,4 +122,6 @@ query!(Query {
     RankFeatureLinear(RankFeatureLinearQuery),
     MoreLikeThis(MoreLikeThisQuery),
     Fuzzy(FuzzyQuery),
+    GeoDistance(GeoDistanceQuery),
+    GeoBoundingBox(GeoBoundingBoxQuery),
 });


### PR DESCRIPTION
This should allow us to use Geo queries with actual query DSL :smile: 

Ref https://github.com/vinted/elasticsearch-dsl-rs/pull/41, https://github.com/vinted/elasticsearch-dsl-rs/pull/49.

Example error:

```
69 | ...                   .should(
   |                        ^^^^^^ the trait `From<GeoDistanceQuery>` is not implemented for `std::option::Option<elasticsearch_dsl::Query>`
```