### PR TITLE
Implement raw JSON query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/src/search/queries/custom/json_query.rs
+++ b/src/search/queries/custom/json_query.rs
@@ -1,0 +1,55 @@
+use crate::search::*;
+use crate::util::*;
+
+/// Raw JSON query for something not yet supported.
+///
+/// To create JSON query:
+/// ```
+/// # use elasticsearch_dsl::queries::*;
+/// # use elasticsearch_dsl::queries::params::*;
+/// # let query =
+/// Query::json(serde_json::json!({ "term": { "user": "username" } }));
+/// ```
+/// **NOTE**: This is fallible and can lead to incorrect queries and
+/// rejected search requests, use ar your own risk.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct JsonQuery(serde_json::Value);
+
+impl Query {
+    /// Creates an instance of [`JsonQuery`]
+    ///
+    /// - `query` - raw JSON query
+    pub fn json(query: serde_json::Value) -> JsonQuery {
+        JsonQuery(query)
+    }
+}
+
+impl From<serde_json::Value> for Query {
+    fn from(value: serde_json::Value) -> Self {
+        Self::Json(JsonQuery(value))
+    }
+}
+
+impl From<serde_json::Value> for JsonQuery {
+    fn from(value: serde_json::Value) -> Self {
+        Self(value)
+    }
+}
+
+impl ShouldSkip for JsonQuery {
+    fn should_skip(&self) -> bool {
+        !self.0.is_object()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    test_serialization! {
+        with_required_fields(
+            Query::json(json!({ "term": { "user": "username" } })),
+            json!({ "term": { "user": "username" } })
+        );
+    }
+}

--- a/src/search/queries/custom/mod.rs
+++ b/src/search/queries/custom/mod.rs
@@ -1,0 +1,5 @@
+//! Non official queries, such as plugins or raw JSON queries
+
+mod json_query;
+
+pub use self::json_query::*;

--- a/src/search/queries/mod.rs
+++ b/src/search/queries/mod.rs
@@ -16,6 +16,7 @@
 pub mod params;
 
 pub mod compound;
+pub mod custom;
 pub mod full_text;
 pub mod geo;
 pub mod joining;
@@ -25,6 +26,7 @@ pub mod specialized;
 pub mod term_level;
 
 pub use self::compound::*;
+pub use self::custom::*;
 pub use self::full_text::*;
 pub use self::geo::*;
 pub use self::joining::*;
@@ -124,4 +126,5 @@ query!(Query {
     Fuzzy(FuzzyQuery),
     GeoDistance(GeoDistanceQuery),
     GeoBoundingBox(GeoBoundingBoxQuery),
+    Json(JsonQuery),
 });


### PR DESCRIPTION
Allow passing a raw JSON query, this might be useful for scaffolding, not-yet-supported queries or queries provided by plugins.