### PR TITLE
Add `From`, `Size` type aliases

### DIFF
--- a/src/search/aggregations/bucket/terms_aggregation.rs
+++ b/src/search/aggregations/bucket/terms_aggregation.rs
@@ -83,7 +83,7 @@ impl TermsAggregation {
     ///
     /// This means that if the number of unique terms is greater than `size`, the returned list is slightly off and not accurate
     /// (it could be that the term counts are slightly off and it could even be that a term that should have been in the top `size` buckets was not returned).
-    pub fn size(mut self, size: impl TryInto<u64>) -> Self {
+    pub fn size(mut self, size: impl TryInto<Size>) -> Self {
         if let Ok(size) = size.try_into() {
             self.terms.size = Some(size);
         }

--- a/src/search/aggregations/metrics/top_hits_aggregation.rs
+++ b/src/search/aggregations/metrics/top_hits_aggregation.rs
@@ -63,7 +63,7 @@ impl TopHitsAggregation {
     }
 
     /// The offset from the first result you want to fetch.
-    pub fn from(mut self, from: impl TryInto<u64>) -> Self {
+    pub fn from(mut self, from: impl TryInto<From>) -> Self {
         if let Ok(from) = from.try_into() {
             self.top_hits.from = Some(from);
         }
@@ -73,7 +73,7 @@ impl TopHitsAggregation {
     /// The maximum number of top matching hits to return per bucket.
     ///
     /// By default the top three matching hits are returned.
-    pub fn size(mut self, size: impl TryInto<u64>) -> Self {
+    pub fn size(mut self, size: impl TryInto<Size>) -> Self {
         if let Ok(size) = size.try_into() {
             self.top_hits.size = Some(size);
         }

--- a/src/search/params/mod.rs
+++ b/src/search/params/mod.rs
@@ -11,3 +11,9 @@ pub use self::numeric::*;
 pub use self::scalar::*;
 pub use self::search::*;
 pub use self::units::*;
+
+/// Size type alias
+pub type Size = u64;
+
+/// From type alias
+pub type From = u64;

--- a/src/search/queries/params/inner_hits.rs
+++ b/src/search/queries/params/inner_hits.rs
@@ -53,7 +53,7 @@ impl InnerHits {
     /// Starting document offset.
     ///
     /// Defaults to `0`.
-    pub fn from(mut self, from: impl TryInto<u64>) -> Self {
+    pub fn from(mut self, from: impl TryInto<From>) -> Self {
         if let Ok(from) = from.try_into() {
             self.from = Some(from);
         }
@@ -63,7 +63,7 @@ impl InnerHits {
     /// The number of hits to return.
     ///
     /// Defaults to `10`.
-    pub fn size(mut self, size: impl TryInto<u64>) -> Self {
+    pub fn size(mut self, size: impl TryInto<Size>) -> Self {
         if let Ok(size) = size.try_into() {
             self.size = Some(size);
         }

--- a/src/search/request.rs
+++ b/src/search/request.rs
@@ -60,7 +60,7 @@ impl Search {
     /// Starting document offset.
     ///
     /// Defaults to `0`.
-    pub fn from(mut self, from: impl TryInto<u64>) -> Self {
+    pub fn from(mut self, from: impl TryInto<From>) -> Self {
         if let Ok(from) = from.try_into() {
             self.from = Some(from);
         }
@@ -70,7 +70,7 @@ impl Search {
     /// The number of hits to return.
     ///
     /// Defaults to `10`.
-    pub fn size(mut self, size: impl TryInto<u64>) -> Self {
+    pub fn size(mut self, size: impl TryInto<Size>) -> Self {
         if let Ok(size) = size.try_into() {
             self.size = Some(size);
         }

--- a/src/search/rescoring/mod.rs
+++ b/src/search/rescoring/mod.rs
@@ -69,7 +69,7 @@ impl Rescore {
     }
 
     /// The number of docs which will be examined on each shard can be controlled by the `window_size` parameter, which defaults to 10.
-    pub fn window_size(mut self, window_size: impl TryInto<u64>) -> Self {
+    pub fn window_size(mut self, window_size: impl TryInto<Size>) -> Self {
         if let Ok(window_size) = window_size.try_into() {
             self.window_size = Some(window_size);
         }


### PR DESCRIPTION
To better self-document code, adding type aliases for from and size values.