### PR TITLE
Rename `Numeric` to `Number`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/src/search/aggregations/metrics/avg_aggregation.rs
+++ b/src/search/aggregations/metrics/avg_aggregation.rs
@@ -18,7 +18,7 @@ struct AvgAggregationInner {
     field: String,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    missing: Option<Numeric>,
+    missing: Option<Number>,
 }
 
 impl Aggregation {
@@ -40,7 +40,7 @@ impl Aggregation {
 impl AvgAggregation {
     /// The missing parameter defines how documents that are missing a value should be treated. By
     /// default they will be ignored but it is also possible to treat them as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Numeric>) -> Self {
+    pub fn missing(mut self, missing: impl Into<Number>) -> Self {
         self.avg.missing = Some(missing.into());
         self
     }

--- a/src/search/aggregations/metrics/boxplot_aggregation.rs
+++ b/src/search/aggregations/metrics/boxplot_aggregation.rs
@@ -1,5 +1,5 @@
 use crate::util::*;
-use crate::{Aggregation, Numeric};
+use crate::{Aggregation, Number};
 
 /// A `boxplot` metrics aggregation that computes boxplot of numeric values extracted from the
 /// aggregated documents. These values can be generated from specific numeric or [histogram fields](https://www.elastic.co/guide/en/elasticsearch/reference/current/histogram.html)
@@ -26,9 +26,9 @@ pub struct BoxplotAggregation {
 struct BoxplotAggregationInner {
     field: String,
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    compression: Option<Numeric>,
+    compression: Option<Number>,
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    missing: Option<Numeric>,
+    missing: Option<Number>,
 }
 
 impl Aggregation {
@@ -63,14 +63,14 @@ impl BoxplotAggregation {
     /// A "node" uses roughly 32 bytes of memory, so under worst-case scenarios (large amount of
     /// data which arrives sorted and in-order) the default settings will produce a TDigest roughly
     /// 64KB in size. In practice data tends to be more random and the TDigest will use less memory.
-    pub fn compression(mut self, compression: impl Into<Numeric>) -> Self {
+    pub fn compression(mut self, compression: impl Into<Number>) -> Self {
         self.boxplot.compression = Some(compression.into());
         self
     }
 
     /// The `missing` parameter defines how documents that are missing a value should be treated.
     /// By default they will be ignored but it is also possible to treat them as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Numeric>) -> Self {
+    pub fn missing(mut self, missing: impl Into<Number>) -> Self {
         self.boxplot.missing = Some(missing.into());
         self
     }

--- a/src/search/aggregations/metrics/max_aggregation.rs
+++ b/src/search/aggregations/metrics/max_aggregation.rs
@@ -21,7 +21,7 @@ struct MaxAggregationInner {
     field: String,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    missing: Option<Numeric>,
+    missing: Option<Number>,
 }
 
 impl Aggregation {
@@ -43,7 +43,7 @@ impl Aggregation {
 impl MaxAggregation {
     /// The `missing` parameter defines how documents that are missing a value should be treated. By
     /// default they will be ignored but it is also possible to treat them as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Numeric>) -> Self {
+    pub fn missing(mut self, missing: impl Into<Number>) -> Self {
         self.max.missing = Some(missing.into());
         self
     }

--- a/src/search/aggregations/metrics/min_aggregation.rs
+++ b/src/search/aggregations/metrics/min_aggregation.rs
@@ -21,7 +21,7 @@ struct MinAggregationInner {
     field: String,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    missing: Option<Numeric>,
+    missing: Option<Number>,
 }
 
 impl Aggregation {
@@ -43,7 +43,7 @@ impl Aggregation {
 impl MinAggregation {
     /// The `missing` parameter defines how documents that are missing a value should be treated. By
     /// default they will be ignored but it is also possible to treat them as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Numeric>) -> Self {
+    pub fn missing(mut self, missing: impl Into<Number>) -> Self {
         self.min.missing = Some(missing.into());
         self
     }

--- a/src/search/aggregations/metrics/sum_aggregation.rs
+++ b/src/search/aggregations/metrics/sum_aggregation.rs
@@ -17,7 +17,7 @@ struct SumAggregationInner {
     field: String,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    missing: Option<Numeric>,
+    missing: Option<Number>,
 }
 
 impl Aggregation {
@@ -40,7 +40,7 @@ impl SumAggregation {
     /// The `missing` parameter defines how documents that are missing a value should be treated. By
     /// default documents missing the value will be ignored but it is also possible to treat them
     /// as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Numeric>) -> Self {
+    pub fn missing(mut self, missing: impl Into<Number>) -> Self {
         self.sum.missing = Some(missing.into());
         self
     }

--- a/src/search/params/mod.rs
+++ b/src/search/params/mod.rs
@@ -1,13 +1,13 @@
 //! Value types accepted by leaf query clauses
 
 mod geo_point;
-mod numeric;
+mod number;
 mod scalar;
 mod search;
 mod units;
 
 pub use self::geo_point::*;
-pub use self::numeric::*;
+pub use self::number::*;
 pub use self::scalar::*;
 pub use self::search::*;
 pub use self::units::*;

--- a/src/search/params/number.rs
+++ b/src/search/params/number.rs
@@ -1,7 +1,7 @@
 /// Numeric enum
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd)]
 #[serde(untagged)]
-pub enum Numeric {
+pub enum Number {
     /// Represents the type of u8, u16, u32, u64
     U64(u64),
     /// Represents the type of i8, i16, i32, i64
@@ -12,61 +12,61 @@ pub enum Numeric {
     F64(f64),
 }
 
-impl From<u8> for Numeric {
+impl From<u8> for Number {
     fn from(value: u8) -> Self {
         Self::U64(value as u64)
     }
 }
 
-impl From<u16> for Numeric {
+impl From<u16> for Number {
     fn from(value: u16) -> Self {
         Self::U64(value as u64)
     }
 }
 
-impl From<u32> for Numeric {
+impl From<u32> for Number {
     fn from(value: u32) -> Self {
         Self::U64(value as u64)
     }
 }
 
-impl From<u64> for Numeric {
+impl From<u64> for Number {
     fn from(value: u64) -> Self {
         Self::U64(value)
     }
 }
 
-impl From<i8> for Numeric {
+impl From<i8> for Number {
     fn from(value: i8) -> Self {
         Self::I64(value as i64)
     }
 }
 
-impl From<i16> for Numeric {
+impl From<i16> for Number {
     fn from(value: i16) -> Self {
         Self::I64(value as i64)
     }
 }
 
-impl From<i32> for Numeric {
+impl From<i32> for Number {
     fn from(value: i32) -> Self {
         Self::I64(value as i64)
     }
 }
 
-impl From<i64> for Numeric {
+impl From<i64> for Number {
     fn from(value: i64) -> Self {
         Self::I64(value)
     }
 }
 
-impl From<f32> for Numeric {
+impl From<f32> for Number {
     fn from(value: f32) -> Self {
         Self::F32(value)
     }
 }
 
-impl From<f64> for Numeric {
+impl From<f64> for Number {
     fn from(value: f64) -> Self {
         Self::F64(value)
     }


### PR DESCRIPTION
This is more English than `Numeric`.

