### PR TITLE
Introduce text type

### DIFF
--- a/src/search/params/mod.rs
+++ b/src/search/params/mod.rs
@@ -4,10 +4,12 @@ mod geo_point;
 mod number;
 mod search;
 mod term;
+mod text;
 mod units;
 
 pub use self::geo_point::*;
 pub use self::number::*;
 pub use self::search::*;
 pub use self::term::*;
+pub use self::text::*;
 pub use self::units::*;

--- a/src/search/params/text.rs
+++ b/src/search/params/text.rs
@@ -1,0 +1,65 @@
+use crate::util::*;
+use std::borrow::Cow;
+
+/// Search text
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct Text(Option<String>);
+
+impl ShouldSkip for Text {
+    fn should_skip(&self) -> bool {
+        self.0.as_ref().map_or(true, ShouldSkip::should_skip)
+    }
+}
+
+impl From<String> for Text {
+    fn from(value: String) -> Self {
+        Self(Some(value))
+    }
+}
+
+impl From<Option<String>> for Text {
+    fn from(value: Option<String>) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for Text {
+    fn from(value: &str) -> Self {
+        Self(Some(value.into()))
+    }
+}
+
+impl From<Option<&str>> for Text {
+    fn from(value: Option<&str>) -> Self {
+        Self(value.map(Into::into))
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for Text {
+    fn from(value: Cow<'a, str>) -> Self {
+        Self(Some(value.into()))
+    }
+}
+
+impl<'a> From<Option<Cow<'a, str>>> for Text {
+    fn from(value: Option<Cow<'a, str>>) -> Self {
+        Self(value.map(Into::into))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn skips_correctly() {
+        assert!(Text::from(None::<String>).should_skip());
+        assert!(Text::from("").should_skip());
+        assert!(Text::from("  ").should_skip());
+    }
+
+    #[test]
+    fn compares_correctly() {
+        assert_eq!(Text::from("abc"), Text::from(Some("abc")));
+    }
+}


### PR DESCRIPTION
Instead of using raw `String`, this introduces a `Text` type (ES convention as well) with conversions from strings and optional strings. Later I'll introduce this in text queries.