### PR TITLE
Revert "Implement Hit PartialEq manually"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.1.9"
+version = "0.1.8"
 authors = ["Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/src/search/response.rs
+++ b/src/search/response.rs
@@ -61,7 +61,7 @@ pub struct Hits<H, IH> {
 }
 
 /// Represents a single matched document
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Hit<H, IH> {
     /// Document index
     #[serde(skip_serializing_if = "ShouldSkip::should_skip", rename = "_index")]
@@ -99,13 +99,6 @@ pub struct Hit<H, IH> {
     /// Field values for the documents. Need to be specified in the request
     #[serde(skip_serializing_if = "ShouldSkip::should_skip", default)]
     pub fields: std::collections::BTreeMap<String, Value>,
-}
-
-/// Hit can be considered equal to another hit when index and id are equal
-impl<H, IH> PartialEq for Hit<H, IH> {
-    fn eq(&self, other: &Self) -> bool {
-        self.index == other.index && self.id == other.id
-    }
 }
 
 /// Represents inner hits


### PR DESCRIPTION
Reverts vinted/elasticsearch-dsl-rs#60

It's better to leave structural equality and let one override if it needed with a newtype