### PR TITLE
Reuse Number in Term

### DIFF
--- a/src/search/params/term.rs
+++ b/src/search/params/term.rs
@@ -1,6 +1,7 @@
+use crate::params::*;
 use crate::util::*;
 use chrono::{DateTime, Utc};
-use std::{cmp::Ordering, convert::TryFrom};
+use std::cmp::Ordering;
 
 /// Leaf term value
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
@@ -15,28 +16,11 @@ enum Inner {
     /// String value
     String(String),
 
-    /// Signed integer value
-    SignedInteger(i64),
-
-    /// Unsigned integer value
-    UnsignedInteger(u64),
-
-    /// Floating 32-bit point value
-    Float32(f32),
-
-    /// Floating 64-bit point value
-    Float64(f64),
+    /// Number value
+    Number(Number),
 
     /// DateTime
     DateTime(DateTime<Utc>),
-}
-
-fn try_eq<L, R>(left: &L, right: &R) -> bool
-where
-    L: TryFrom<R> + PartialEq + Copy,
-    R: PartialEq + Copy,
-{
-    L::try_from(*right).map_or(false, |r| left.eq(&r))
 }
 
 impl PartialEq for Inner {
@@ -44,14 +28,7 @@ impl PartialEq for Inner {
         match (self, other) {
             (Inner::Bool(s), Inner::Bool(o)) => s.eq(o),
             (Inner::String(s), Inner::String(o)) => s.eq(o),
-            (Inner::SignedInteger(s), Inner::SignedInteger(o)) => s.eq(o),
-            (Inner::SignedInteger(s), Inner::UnsignedInteger(o)) => try_eq(s, o),
-            (Inner::UnsignedInteger(s), Inner::SignedInteger(o)) => try_eq(s, o),
-            (Inner::UnsignedInteger(s), Inner::UnsignedInteger(o)) => s.eq(o),
-            (Inner::Float32(s), Inner::Float32(o)) => s.eq(o),
-            (Inner::Float32(s), Inner::Float64(o)) => try_eq(o, s),
-            (Inner::Float64(s), Inner::Float32(o)) => try_eq(s, o),
-            (Inner::Float64(s), Inner::Float64(o)) => s.eq(o),
+            (Inner::Number(s), Inner::Number(o)) => s.eq(o),
             (Inner::DateTime(s), Inner::DateTime(o)) => s.eq(o),
             _ => false,
         }
@@ -65,10 +42,7 @@ impl PartialOrd for Inner {
         match (&self, other) {
             (Self::Bool(s), Self::Bool(o)) => s.partial_cmp(o),
             (Self::String(s), Self::String(o)) => s.partial_cmp(o),
-            (Self::SignedInteger(s), Self::SignedInteger(o)) => s.partial_cmp(o),
-            (Self::UnsignedInteger(s), Self::UnsignedInteger(o)) => s.partial_cmp(o),
-            (Self::Float32(s), Self::Float32(o)) => s.partial_cmp(o),
-            (Self::Float64(s), Self::Float64(o)) => s.partial_cmp(o),
+            (Self::Number(s), Self::Number(o)) => s.partial_cmp(o),
             (Self::DateTime(s), Self::DateTime(o)) => s.partial_cmp(o),
             _ => Some(Ordering::Less),
         }
@@ -80,10 +54,7 @@ impl Ord for Inner {
         match (&self, other) {
             (Self::Bool(s), Self::Bool(o)) => s.cmp(o),
             (Self::String(s), Self::String(o)) => s.cmp(o),
-            (Self::SignedInteger(s), Self::SignedInteger(o)) => s.cmp(o),
-            (Self::UnsignedInteger(s), Self::UnsignedInteger(o)) => s.cmp(o),
-            (Self::Float32(s), Self::Float32(o)) => s.partial_cmp(o).unwrap_or(Ordering::Less),
-            (Self::Float64(s), Self::Float64(o)) => s.partial_cmp(o).unwrap_or(Ordering::Less),
+            (Self::Number(s), Self::Number(o)) => s.partial_cmp(o).unwrap_or(Ordering::Less),
             (Self::DateTime(s), Self::DateTime(o)) => s.cmp(o),
             _ => Ordering::Less,
         }
@@ -110,61 +81,61 @@ impl From<&str> for Term {
 
 impl From<i8> for Term {
     fn from(value: i8) -> Self {
-        Self(Some(Inner::SignedInteger(value as i64)))
+        Self(Some(Inner::Number(Number::from(value))))
     }
 }
 
 impl From<i16> for Term {
     fn from(value: i16) -> Self {
-        Self(Some(Inner::SignedInteger(value as i64)))
+        Self(Some(Inner::Number(Number::from(value))))
     }
 }
 
 impl From<i32> for Term {
     fn from(value: i32) -> Self {
-        Self(Some(Inner::SignedInteger(value as i64)))
+        Self(Some(Inner::Number(Number::from(value))))
     }
 }
 
 impl From<i64> for Term {
     fn from(value: i64) -> Self {
-        Self(Some(Inner::SignedInteger(value)))
+        Self(Some(Inner::Number(Number::from(value))))
     }
 }
 
 impl From<u8> for Term {
     fn from(value: u8) -> Self {
-        Self(Some(Inner::UnsignedInteger(value as u64)))
+        Self(Some(Inner::Number(Number::from(value))))
     }
 }
 
 impl From<u16> for Term {
     fn from(value: u16) -> Self {
-        Self(Some(Inner::UnsignedInteger(value as u64)))
+        Self(Some(Inner::Number(Number::from(value))))
     }
 }
 
 impl From<u32> for Term {
     fn from(value: u32) -> Self {
-        Self(Some(Inner::UnsignedInteger(value as u64)))
+        Self(Some(Inner::Number(Number::from(value))))
     }
 }
 
 impl From<u64> for Term {
     fn from(value: u64) -> Self {
-        Self(Some(Inner::UnsignedInteger(value)))
+        Self(Some(Inner::Number(Number::from(value))))
     }
 }
 
 impl From<f32> for Term {
     fn from(value: f32) -> Self {
-        Self(Some(Inner::Float32(value)))
+        Self(Some(Inner::Number(Number::from(value))))
     }
 }
 
 impl From<f64> for Term {
     fn from(value: f64) -> Self {
-        Self(Some(Inner::Float64(value)))
+        Self(Some(Inner::Number(Number::from(value))))
     }
 }
 
@@ -193,61 +164,61 @@ impl From<Option<&str>> for Term {
 
 impl From<Option<i8>> for Term {
     fn from(value: Option<i8>) -> Self {
-        Self(value.map(i64::from).map(Inner::SignedInteger))
+        Self(value.map(Number::from).map(Inner::Number))
     }
 }
 
 impl From<Option<i16>> for Term {
     fn from(value: Option<i16>) -> Self {
-        Self(value.map(i64::from).map(Inner::SignedInteger))
+        Self(value.map(Number::from).map(Inner::Number))
     }
 }
 
 impl From<Option<i32>> for Term {
     fn from(value: Option<i32>) -> Self {
-        Self(value.map(i64::from).map(Inner::SignedInteger))
+        Self(value.map(Number::from).map(Inner::Number))
     }
 }
 
 impl From<Option<i64>> for Term {
     fn from(value: Option<i64>) -> Self {
-        Self(value.map(Inner::SignedInteger))
+        Self(value.map(Number::from).map(Inner::Number))
     }
 }
 
 impl From<Option<u8>> for Term {
     fn from(value: Option<u8>) -> Self {
-        Self(value.map(u64::from).map(Inner::UnsignedInteger))
+        Self(value.map(Number::from).map(Inner::Number))
     }
 }
 
 impl From<Option<u16>> for Term {
     fn from(value: Option<u16>) -> Self {
-        Self(value.map(u64::from).map(Inner::UnsignedInteger))
+        Self(value.map(Number::from).map(Inner::Number))
     }
 }
 
 impl From<Option<u32>> for Term {
     fn from(value: Option<u32>) -> Self {
-        Self(value.map(u64::from).map(Inner::UnsignedInteger))
+        Self(value.map(Number::from).map(Inner::Number))
     }
 }
 
 impl From<Option<u64>> for Term {
     fn from(value: Option<u64>) -> Self {
-        Self(value.map(Inner::UnsignedInteger))
+        Self(value.map(Number::from).map(Inner::Number))
     }
 }
 
 impl From<Option<f32>> for Term {
     fn from(value: Option<f32>) -> Self {
-        Self(value.map(Inner::Float32))
+        Self(value.map(Number::from).map(Inner::Number))
     }
 }
 
 impl From<Option<f64>> for Term {
     fn from(value: Option<f64>) -> Self {
-        Self(value.map(Inner::Float64))
+        Self(value.map(Number::from).map(Inner::Number))
     }
 }
 
@@ -275,19 +246,17 @@ mod tests {
     #[test]
     fn partial_equality() {
         let values = vec![
-            (Inner::Bool(true), Inner::Bool(true)),
-            (Inner::String("a".into()), Inner::String("a".into())),
-            (Inner::SignedInteger(16), Inner::SignedInteger(16)),
-            (Inner::SignedInteger(16), Inner::UnsignedInteger(16)),
-            (Inner::UnsignedInteger(16), Inner::SignedInteger(16)),
-            (Inner::UnsignedInteger(16), Inner::UnsignedInteger(16)),
-            (Inner::Float32(1.), Inner::Float32(1.)),
-            (Inner::Float32(1.), Inner::Float64(1.)),
-            (Inner::Float64(1.), Inner::Float32(1.)),
-            (Inner::Float64(1.), Inner::Float64(1.)),
+            (Term::from(true), Term::from(true)),
+            (Term::from("a"), Term::from("a")),
+            (Term::from(16), Term::from(16)),
+            (Term::from(-1), Term::from(-1)),
+            (Term::from(1f32), Term::from(1f32)),
+            (Term::from(1f32), Term::from(1f64)),
+            (Term::from(1f64), Term::from(1f32)),
+            (Term::from(1f64), Term::from(1f64)),
             (
-                Inner::DateTime(Utc.ymd(2021, 3, 10).and_hms(10, 42, 0)),
-                Inner::DateTime(Utc.ymd(2021, 3, 10).and_hms(10, 42, 0)),
+                Term::from(Utc.ymd(2021, 3, 10).and_hms(10, 42, 0)),
+                Term::from(Utc.ymd(2021, 3, 10).and_hms(10, 42, 0)),
             ),
         ];
 


### PR DESCRIPTION
To avoid logic duplication, Term enum will now use Number to represent a single number instead of multiple variants that Number now implements.