### PR TITLE
Cleanup date, number, term

### DIFF
--- a/src/search/params/date.rs
+++ b/src/search/params/date.rs
@@ -1,6 +1,8 @@
+use chrono::{DateTime, Utc};
 use std::time::SystemTime;
 
-type ChronoTime = chrono::DateTime<chrono::Utc>;
+/// [`DateTime<Utc>`] type alias
+pub type ChronoTime = DateTime<Utc>;
 
 /// Time variants to serialize
 #[derive(Debug, Clone, Copy, Serialize)]

--- a/src/search/params/number.rs
+++ b/src/search/params/number.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 
 /// Numeric enum
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Number(N);
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
@@ -9,10 +9,13 @@ pub struct Number(N);
 enum N {
     /// Non-negative integers
     Pos(u64),
+
     /// Negative integers
     Neg(i64),
+
     /// 32-bit floats
     F32(f32),
+
     /// 64-bit floats
     F64(f64),
 }
@@ -214,6 +217,8 @@ impl PartialEq for N {
     }
 }
 
+impl Eq for N {}
+
 impl PartialOrd for N {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         match (self, other) {
@@ -241,6 +246,12 @@ impl PartialOrd for N {
             (N::F64(value), N::F32(other)) => (*value as f32).partial_cmp(other),
             (N::F64(value), N::F64(other)) => value.partial_cmp(other),
         }
+    }
+}
+
+impl Ord for N {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap_or(Ordering::Less)
     }
 }
 

--- a/src/search/params/term.rs
+++ b/src/search/params/term.rs
@@ -1,14 +1,13 @@
 use crate::params::*;
 use crate::util::*;
 use chrono::{DateTime, Utc};
-use std::cmp::Ordering;
 use std::time::SystemTime;
 
 /// Leaf term value
 #[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct Term(Option<Inner>);
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(untagged)]
 enum Inner {
     /// Boolean value
@@ -22,44 +21,6 @@ enum Inner {
 
     /// Date
     Date(Date),
-}
-
-impl PartialEq for Inner {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Inner::Bool(s), Inner::Bool(o)) => s.eq(o),
-            (Inner::String(s), Inner::String(o)) => s.eq(o),
-            (Inner::Number(s), Inner::Number(o)) => s.eq(o),
-            (Inner::Date(s), Inner::Date(o)) => s.eq(o),
-            _ => false,
-        }
-    }
-}
-
-impl Eq for Inner {}
-
-impl PartialOrd for Inner {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        match (&self, other) {
-            (Self::Bool(s), Self::Bool(o)) => s.partial_cmp(o),
-            (Self::String(s), Self::String(o)) => s.partial_cmp(o),
-            (Self::Number(s), Self::Number(o)) => s.partial_cmp(o),
-            (Self::Date(s), Self::Date(o)) => s.partial_cmp(o),
-            _ => Some(Ordering::Less),
-        }
-    }
-}
-
-impl Ord for Inner {
-    fn cmp(&self, other: &Self) -> Ordering {
-        match (&self, other) {
-            (Self::Bool(s), Self::Bool(o)) => s.cmp(o),
-            (Self::String(s), Self::String(o)) => s.cmp(o),
-            (Self::Number(s), Self::Number(o)) => s.partial_cmp(o).unwrap_or(Ordering::Less),
-            (Self::Date(s), Self::Date(o)) => s.cmp(o),
-            _ => Ordering::Less,
-        }
-    }
 }
 
 impl From<bool> for Term {


### PR DESCRIPTION
Custom order and ordering implementations were done for number variant only, they are now handled in Number struct.