### PR TITLE
Fix TieBreaker implementation

### DIFF
--- a/src/search/queries/compound/dis_max_query.rs
+++ b/src/search/queries/compound/dis_max_query.rs
@@ -1,5 +1,6 @@
 use crate::search::*;
 use crate::util::*;
+
 /// Returns documents matching one or more wrapped queries, called query clauses or clauses.
 ///
 /// If a returned document matches multiple query clauses, the `dis_max` query assigns the document
@@ -96,9 +97,11 @@ impl DisMaxQuery {
     /// count, but the clause with the highest score counts most.
     pub fn tie_breaker<T>(mut self, tie_breaker: T) -> Self
     where
-        T: Into<TieBreaker>,
+        T: std::convert::TryInto<TieBreaker>,
     {
-        self.inner.tie_breaker = Some(tie_breaker.into());
+        if let Ok(tie_breaker) = tie_breaker.try_into() {
+            self.inner.tie_breaker = Some(tie_breaker);
+        }
         self
     }
 

--- a/src/search/queries/full_text/multi_match_query.rs
+++ b/src/search/queries/full_text/multi_match_query.rs
@@ -242,6 +242,7 @@ impl ShouldSkip for MultiMatchQuery {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::convert::TryFrom;
 
     #[test]
     fn serialization() {
@@ -257,7 +258,9 @@ mod tests {
 
         assert_serialize(
             Query::multi_match(["test"], "search text")
-                .r#type(MultiMatchQueryType::BestFields(Some(TieBreaker::from(0.2))))
+                .r#type(MultiMatchQueryType::BestFields(
+                    TieBreaker::try_from(0.2).ok(),
+                ))
                 .analyzer("search_time_analyzer")
                 .auto_generate_synonyms_phrase_query(true)
                 .fuzziness(23)

--- a/src/search/queries/params/tie_breaker.rs
+++ b/src/search/queries/params/tie_breaker.rs
@@ -1,3 +1,5 @@
+use std::convert::TryFrom;
+
 /// Floating point number between `0` and `1.0` used to increase the
 /// [relevance scores](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores)
 /// of documents matching multiple query clauses. Defaults to `0.0`.
@@ -25,17 +27,18 @@ impl TieBreaker {
 
     /// Maximum value
     const MAXIMUM: f32 = 1f32;
-
-    /// Creates a new instance of `tie_breaker` value
-    pub fn new(value: f32) -> Self {
-        let value = f32::min(f32::max(Self::MINIMUM, value), Self::MAXIMUM);
-
-        Self(value)
-    }
 }
 
-impl From<f32> for TieBreaker {
-    fn from(value: f32) -> Self {
-        Self::new(value)
+impl TryFrom<f32> for TieBreaker {
+    type Error = &'static str;
+
+    fn try_from(value: f32) -> Result<Self, Self::Error> {
+        if value < Self::MINIMUM {
+            Err("Value cannot be lower than 0")
+        } else if value > Self::MAXIMUM {
+            Err("Value cannot be greater than 1")
+        } else {
+            Ok(Self(value))
+        }
     }
 }


### PR DESCRIPTION
It was incorrect to use from implementation and cap the result. This will use try from instead.