### PR TITLE
Refactor aggregations builder

### DIFF
--- a/examples/aggregations/Cargo.toml
+++ b/examples/aggregations/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "aggregations"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+elasticsearch-dsl = { path = "../.." }
+serde_json = { version = "1" }

--- a/examples/aggregations/src/main.rs
+++ b/examples/aggregations/src/main.rs
@@ -1,0 +1,21 @@
+use elasticsearch_dsl::*;
+
+fn main() {
+    let search = Search::new()
+        .size(0)
+        .query(Query::bool().must_not(Query::exists("country_id")))
+        .aggregate(
+            "country_ids",
+            Aggregation::terms("country_id")
+                .aggregate("catalog_ids", Aggregation::terms("catalog_id"))
+                .aggregate("company_ids", Aggregation::terms("company_id"))
+                .aggregate(
+                    "top1",
+                    Aggregation::top_hits()
+                        .size(1)
+                        .sort(Sort::new(SortField::Id).order(SortOrder::Desc)),
+                ),
+        );
+
+    println!("{}", serde_json::to_string_pretty(&search).unwrap());
+}

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -42,12 +42,13 @@ macro_rules! add_boost_and_name {
 macro_rules! add_aggregate {
     () => {
         /// Pushes aggregation
-        pub fn aggregate<A>(mut self, aggregation: A) -> Self
+        pub fn aggregate<N, A>(mut self, aggregation_name: N, aggregation: A) -> Self
         where
+            N: Into<AggregationName>,
             A: Into<Aggregation>,
         {
             let a = aggregation.into();
-            let _ = self.aggs.entry(a.name()).or_insert(a);
+            let _ = self.aggs.entry(aggregation_name.into()).or_insert(a);
             self
         }
     };

--- a/src/search/aggregations/bucket/terms_aggregation.rs
+++ b/src/search/aggregations/bucket/terms_aggregation.rs
@@ -7,12 +7,10 @@ use std::convert::TryInto;
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html>
 pub struct TermsAggregation {
-    #[serde(skip_serializing)]
-    pub(crate) name: String,
     terms: TermsAggregationInner,
-    /// Sub-aggregations
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    pub(crate) aggs: Aggregations,
+    aggs: Aggregations,
 }
 
 #[derive(Debug, Clone, Serialize, PartialEq)]
@@ -58,11 +56,9 @@ where
 impl Aggregation {
     /// Creates an instance of [`TermsAggregation`]
     ///
-    /// - `name` - name of the aggregation
     /// - `field` - field to group by
-    pub fn terms(name: impl Into<String>, field: impl Into<String>) -> TermsAggregation {
+    pub fn terms(field: impl Into<String>) -> TermsAggregation {
         TermsAggregation {
-            name: name.into(),
             terms: TermsAggregationInner {
                 field: field.into(),
                 size: None,
@@ -134,12 +130,12 @@ mod tests {
     #[test]
     fn serialization() {
         assert_serialize(
-            Aggregation::terms("test_agg", "test_field"),
+            Aggregation::terms("test_field"),
             json!({ "terms": { "field": "test_field" } }),
         );
 
         assert_serialize(
-            Aggregation::terms("test_agg", "test_field")
+            Aggregation::terms("test_field")
                 .size(5u16)
                 .min_doc_count(2u16)
                 .show_term_doc_count_error(false)
@@ -158,10 +154,10 @@ mod tests {
         );
 
         assert_serialize(
-            Aggregation::terms("test_agg", "test_field")
+            Aggregation::terms("test_field")
                 .size(0u16)
                 .order(("test_order", SortOrder::Asc))
-                .aggregate(Aggregation::terms("test_sub_agg", "test_field2").size(3u16)),
+                .aggregate("test_sub_agg", Aggregation::terms("test_field2").size(3u16)),
             json!({
                 "terms": {
                     "field": "test_field",

--- a/src/search/aggregations/metrics/avg_aggregation.rs
+++ b/src/search/aggregations/metrics/avg_aggregation.rs
@@ -8,8 +8,6 @@ use crate::util::*;
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-avg-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct AvgAggregation {
-    #[serde(skip_serializing)]
-    pub(crate) name: String,
     avg: AvgAggregationInner,
 }
 
@@ -24,11 +22,9 @@ struct AvgAggregationInner {
 impl Aggregation {
     /// Creates an instance of [`AvgAggregation`]
     ///
-    /// - `name` - name of the aggregation
     /// - `field` - field to aggregate
-    pub fn avg(name: impl Into<String>, field: impl Into<String>) -> AvgAggregation {
+    pub fn avg(field: impl Into<String>) -> AvgAggregation {
         AvgAggregation {
-            name: name.into(),
             avg: AvgAggregationInner {
                 field: field.into(),
                 missing: None,
@@ -53,12 +49,12 @@ mod tests {
     #[test]
     fn serialization() {
         assert_serialize(
-            Aggregation::avg("test_avg", "test_field"),
+            Aggregation::avg("test_field"),
             json!({ "avg": { "field": "test_field" } }),
         );
 
         assert_serialize(
-            Aggregation::avg("test_avg", "test_field").missing(100.1),
+            Aggregation::avg("test_field").missing(100.1),
             json!({
                 "avg": {
                     "field": "test_field",

--- a/src/search/aggregations/metrics/boxplot_aggregation.rs
+++ b/src/search/aggregations/metrics/boxplot_aggregation.rs
@@ -17,8 +17,6 @@ use crate::{Aggregation, Number};
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-boxplot-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct BoxplotAggregation {
-    #[serde(skip_serializing)]
-    pub(crate) name: String,
     boxplot: BoxplotAggregationInner,
 }
 
@@ -34,11 +32,9 @@ struct BoxplotAggregationInner {
 impl Aggregation {
     /// Creates an instance of [`BoxplotAggregation`]
     ///
-    /// - `name` - name of the aggregation
     /// - `field` - field to aggregate
-    pub fn boxplot(name: impl Into<String>, field: impl Into<String>) -> BoxplotAggregation {
+    pub fn boxplot(field: impl Into<String>) -> BoxplotAggregation {
         BoxplotAggregation {
-            name: name.into(),
             boxplot: BoxplotAggregationInner {
                 field: field.into(),
                 compression: None,
@@ -83,12 +79,12 @@ mod tests {
     #[test]
     fn serialization() {
         assert_serialize(
-            Aggregation::boxplot("test_boxplot", "test_field"),
+            Aggregation::boxplot("test_field"),
             json!({ "boxplot": { "field": "test_field" } }),
         );
 
         assert_serialize(
-            Aggregation::boxplot("test_boxplot", "test_field")
+            Aggregation::boxplot("test_field")
                 .compression(100)
                 .missing(10),
             json!({

--- a/src/search/aggregations/metrics/cardinality_aggregation.rs
+++ b/src/search/aggregations/metrics/cardinality_aggregation.rs
@@ -6,8 +6,6 @@ use crate::util::*;
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct CardinalityAggregation {
-    #[serde(skip_serializing)]
-    pub(crate) name: String,
     cardinality: CardinalityAggregationInner,
 }
 
@@ -25,14 +23,9 @@ struct CardinalityAggregationInner {
 impl Aggregation {
     /// Creates an instance of [`CardinalityAggregation`]
     ///
-    /// - `name` - name of the aggregation
     /// - `field` - field to aggregate
-    pub fn cardinality(
-        name: impl Into<String>,
-        field: impl Into<String>,
-    ) -> CardinalityAggregation {
+    pub fn cardinality(field: impl Into<String>) -> CardinalityAggregation {
         CardinalityAggregation {
-            name: name.into(),
             cardinality: CardinalityAggregationInner {
                 field: field.into(),
                 precision_threshold: None,
@@ -67,12 +60,12 @@ mod tests {
     #[test]
     fn serialization() {
         assert_serialize(
-            Aggregation::cardinality("test_cardinality", "test_field"),
+            Aggregation::cardinality("test_field"),
             json!({ "cardinality": { "field": "test_field" } }),
         );
 
         assert_serialize(
-            Aggregation::cardinality("test_cardinality", "test_field")
+            Aggregation::cardinality("test_field")
                 .precision_threshold(100u16)
                 .missing("N/A"),
             json!({

--- a/src/search/aggregations/metrics/max_aggregation.rs
+++ b/src/search/aggregations/metrics/max_aggregation.rs
@@ -11,8 +11,6 @@ use crate::util::*;
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct MaxAggregation {
-    #[serde(skip_serializing)]
-    pub(crate) name: String,
     max: MaxAggregationInner,
 }
 
@@ -27,11 +25,9 @@ struct MaxAggregationInner {
 impl Aggregation {
     /// Creates an instance of [`MaxAggregation`]
     ///
-    /// - `name` - name of the aggregation
     /// - `field` - field to aggregate
-    pub fn max(name: impl Into<String>, field: impl Into<String>) -> MaxAggregation {
+    pub fn max(field: impl Into<String>) -> MaxAggregation {
         MaxAggregation {
-            name: name.into(),
             max: MaxAggregationInner {
                 field: field.into(),
                 missing: None,
@@ -56,12 +52,12 @@ mod tests {
     #[test]
     fn serialization() {
         assert_serialize(
-            Aggregation::max("test_max", "test_field"),
+            Aggregation::max("test_field"),
             json!({ "max": { "field": "test_field" } }),
         );
 
         assert_serialize(
-            Aggregation::max("test_max", "test_field").missing(100.1),
+            Aggregation::max("test_field").missing(100.1),
             json!({
                 "max": {
                     "field": "test_field",

--- a/src/search/aggregations/metrics/min_aggregation.rs
+++ b/src/search/aggregations/metrics/min_aggregation.rs
@@ -11,8 +11,6 @@ use crate::util::*;
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct MinAggregation {
-    #[serde(skip_serializing)]
-    pub(crate) name: String,
     min: MinAggregationInner,
 }
 
@@ -27,11 +25,9 @@ struct MinAggregationInner {
 impl Aggregation {
     /// Creates an instance of [`MinAggregation`]
     ///
-    /// - `name` - name of the aggregation
     /// - `field` - field to aggregate
-    pub fn min(name: impl Into<String>, field: impl Into<String>) -> MinAggregation {
+    pub fn min(field: impl Into<String>) -> MinAggregation {
         MinAggregation {
-            name: name.into(),
             min: MinAggregationInner {
                 field: field.into(),
                 missing: None,
@@ -56,12 +52,12 @@ mod tests {
     #[test]
     fn serialization() {
         assert_serialize(
-            Aggregation::min("test_min", "test_field"),
+            Aggregation::min("test_field"),
             json!({ "min": { "field": "test_field" } }),
         );
 
         assert_serialize(
-            Aggregation::min("test_min", "test_field").missing(100.1),
+            Aggregation::min("test_field").missing(100.1),
             json!({
                 "min": {
                     "field": "test_field",

--- a/src/search/aggregations/metrics/rate_aggregation.rs
+++ b/src/search/aggregations/metrics/rate_aggregation.rs
@@ -9,8 +9,6 @@ use crate::util::*;
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-rate-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct RateAggregation {
-    #[serde(skip_serializing)]
-    pub(crate) name: String,
     rate: RateAggregationInner,
 }
 
@@ -26,11 +24,8 @@ struct RateAggregationInner {
 
 impl Aggregation {
     /// Creates an instance of [`RateAggregation`]
-    ///
-    /// - `name` - name of the aggregation
-    pub fn rate(name: impl Into<String>) -> RateAggregation {
+    pub fn rate() -> RateAggregation {
         RateAggregation {
-            name: name.into(),
             rate: RateAggregationInner {
                 field: None,
                 unit: None,
@@ -79,10 +74,10 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(Aggregation::rate("test_rate"), json!({ "rate": { } }));
+        assert_serialize(Aggregation::rate(), json!({ "rate": { } }));
 
         assert_serialize(
-            Aggregation::rate("test_rate")
+            Aggregation::rate()
                 .field("price")
                 .unit(CalendarInterval::Day)
                 .mode(RateMode::ValueCount),

--- a/src/search/aggregations/metrics/sum_aggregation.rs
+++ b/src/search/aggregations/metrics/sum_aggregation.rs
@@ -7,8 +7,6 @@ use crate::util::*;
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-sum-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct SumAggregation {
-    #[serde(skip_serializing)]
-    pub(crate) name: String,
     sum: SumAggregationInner,
 }
 
@@ -23,11 +21,9 @@ struct SumAggregationInner {
 impl Aggregation {
     /// Creates an instance of [`SumAggregation`]
     ///
-    /// - `name` - name of the aggregation
     /// - `field` - field to aggregate
-    pub fn sum(name: impl Into<String>, field: impl Into<String>) -> SumAggregation {
+    pub fn sum(field: impl Into<String>) -> SumAggregation {
         SumAggregation {
-            name: name.into(),
             sum: SumAggregationInner {
                 field: field.into(),
                 missing: None,
@@ -53,12 +49,12 @@ mod tests {
     #[test]
     fn serialization() {
         assert_serialize(
-            Aggregation::sum("test_sum", "test_field"),
+            Aggregation::sum("test_field"),
             json!({ "sum": { "field": "test_field" } }),
         );
 
         assert_serialize(
-            Aggregation::sum("test_sum", "test_field").missing(100.1),
+            Aggregation::sum("test_field").missing(100.1),
             json!({
                 "sum": {
                     "field": "test_field",

--- a/src/search/aggregations/metrics/top_hits_aggregation.rs
+++ b/src/search/aggregations/metrics/top_hits_aggregation.rs
@@ -18,8 +18,6 @@ use std::convert::TryInto;
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-top-hits-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]
 pub struct TopHitsAggregation {
-    #[serde(skip_serializing)]
-    pub(crate) name: String,
     top_hits: TopHitsAggregationInner,
 }
 
@@ -40,11 +38,8 @@ struct TopHitsAggregationInner {
 
 impl Aggregation {
     /// Creates an instance of [`TopHitsAggregation`]
-    ///
-    /// - `name` - name of the aggregation
-    pub fn top_hits(name: impl Into<String>) -> TopHitsAggregation {
+    pub fn top_hits() -> TopHitsAggregation {
         TopHitsAggregation {
-            name: name.into(),
             top_hits: TopHitsAggregationInner {
                 _source: None,
                 from: None,
@@ -93,13 +88,10 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
-            Aggregation::top_hits("test_agg"),
-            json!({ "top_hits": { } }),
-        );
+        assert_serialize(Aggregation::top_hits(), json!({ "top_hits": { } }));
 
         assert_serialize(
-            Aggregation::top_hits("test_agg")
+            Aggregation::top_hits()
                 .source(false)
                 .from(2u8)
                 .size(10u8)

--- a/src/search/aggregations/mod.rs
+++ b/src/search/aggregations/mod.rs
@@ -24,39 +24,28 @@ pub use self::params::*;
 pub use self::pipeline::*;
 
 macro_rules! aggregation {
-    ($name:ident { $($variant:ident($query:ty)),+ $(,)? }) => {
+    ($($variant:ident($query:ty)),+ $(,)?) => {
         /// A container enum for supported Elasticsearch query types
         #[derive(Debug, Clone, PartialEq, Serialize)]
         #[serde(untagged)]
         #[allow(missing_docs)]
-        pub enum $name {
+        pub enum Aggregation {
             $(
                 $variant($query),
             )*
         }
 
         $(
-            impl From<$query> for $name {
+            impl From<$query> for Aggregation {
                 fn from(q: $query) -> Self {
-                    $name::$variant(q)
+                    Aggregation::$variant(q)
                 }
             }
         )+
-
-        impl $name {
-            /// Gets aggregation name
-            pub fn name(&self) -> String {
-                match self {
-                    $(
-                        Self::$variant(a) => a.name.clone(),
-                    )+
-                }
-            }
-        }
     };
 }
 
-aggregation!(Aggregation {
+aggregation!(
     Terms(TermsAggregation),
     TopHits(TopHitsAggregation),
     Cardinality(CardinalityAggregation),
@@ -65,7 +54,7 @@ aggregation!(Aggregation {
     Min(MinAggregation),
     Sum(SumAggregation),
     Rate(RateAggregation),
-});
+);
 
 /// Type alias for a collection of aggregations
-pub type Aggregations = std::collections::BTreeMap<String, Aggregation>;
+pub type Aggregations = std::collections::BTreeMap<AggregationName, Aggregation>;

--- a/src/search/aggregations/params/aggregation_name.rs
+++ b/src/search/aggregations/params/aggregation_name.rs
@@ -1,0 +1,12 @@
+/// Aggregation name
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct AggregationName(String);
+
+impl<T> From<T> for AggregationName
+where
+    T: ToString,
+{
+    fn from(value: T) -> Self {
+        Self(value.to_string())
+    }
+}

--- a/src/search/aggregations/params/mod.rs
+++ b/src/search/aggregations/params/mod.rs
@@ -1,7 +1,9 @@
 //! Value types accepted by aggregation clauses
 
 // Common parameters
+mod aggregation_name;
 mod rate_mode;
 
 // Public re-exports
+pub use self::aggregation_name::*;
 pub use self::rate_mode::*;

--- a/src/search/request.rs
+++ b/src/search/request.rs
@@ -46,21 +46,30 @@ impl Search {
     }
 
     /// Indicates which source fields are returned for matching documents
-    pub fn source(mut self, source: impl Into<SourceFilter>) -> Self {
+    pub fn source<S>(mut self, source: S) -> Self
+    where
+        S: Into<SourceFilter>,
+    {
         self._source = Some(source.into());
         self
     }
 
     /// Specific `tag` of the request for logging and statistical purposes.
-    pub fn stats(mut self, stats: impl Into<String>) -> Self {
-        self.stats.push(stats.into());
+    pub fn stats<S>(mut self, stats: S) -> Self
+    where
+        S: ToString,
+    {
+        self.stats.push(stats.to_string());
         self
     }
 
     /// Starting document offset.
     ///
     /// Defaults to `0`.
-    pub fn from(mut self, from: impl TryInto<u64>) -> Self {
+    pub fn from<S>(mut self, from: S) -> Self
+    where
+        S: TryInto<u64>,
+    {
         if let Ok(from) = from.try_into() {
             self.from = Some(from);
         }
@@ -70,7 +79,10 @@ impl Search {
     /// The number of hits to return.
     ///
     /// Defaults to `10`.
-    pub fn size(mut self, size: impl TryInto<u64>) -> Self {
+    pub fn size<S>(mut self, size: S) -> Self
+    where
+        S: TryInto<u64>,
+    {
         if let Ok(size) = size.try_into() {
             self.size = Some(size);
         }
@@ -79,38 +91,46 @@ impl Search {
 
     /// Defines the search definition using the
     /// [Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html).
-    pub fn query(mut self, query: impl Into<Query>) -> Self {
+    pub fn query<Q>(mut self, query: Q) -> Self
+    where
+        Q: Into<Query>,
+    {
         self.query = Some(query.into());
         self
     }
 
     /// A collection of sorting fields
-    pub fn sort(mut self, sort: impl Into<Vec<Sort>>) -> Self {
+    pub fn sort<S>(mut self, sort: S) -> Self
+    where
+        S: Into<Vec<Sort>>,
+    {
         self.sort.extend(sort.into());
         self
     }
 
-    /// Aggregations
-    pub fn aggregate(mut self, aggregation: impl Into<Aggregation>) -> Self {
-        let aggregation = aggregation.into();
-        let _ = self.aggs.entry(aggregation.name()).or_insert(aggregation);
-        self
-    }
-
     /// Track total hits
-    pub fn track_total_hits(mut self, track_total_hits: impl Into<TrackTotalHits>) -> Self {
+    pub fn track_total_hits<T>(mut self, track_total_hits: T) -> Self
+    where
+        T: Into<TrackTotalHits>,
+    {
         self.track_total_hits = Some(track_total_hits.into());
         self
     }
 
     /// Highlight
-    pub fn highlight(mut self, highlight: impl Into<Highlight>) -> Self {
+    pub fn highlight<H>(mut self, highlight: H) -> Self
+    where
+        H: Into<Highlight>,
+    {
         self.highlight = Some(highlight.into());
         self
     }
 
     /// Rescore
-    pub fn rescore(mut self, rescore: impl Into<Rescore>) -> Self {
+    pub fn rescore<R>(mut self, rescore: R) -> Self
+    where
+        R: Into<Rescore>,
+    {
         let rescore = rescore.into();
 
         if !rescore.should_skip() {
@@ -119,4 +139,6 @@ impl Search {
 
         self
     }
+
+    add_aggregate!();
 }


### PR DESCRIPTION
This is a breaking change that removes `name` from the aggregation itself and moves it onto `.aggregate(aggregation_name, aggregation)` method where it actually always belonged, this makes API more consistent, clearer. It also adds a AggregationName newtype.