### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.1.13"
+version = "0.2.0"
 authors = ["Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add `elasticsearch-dsl` crate and version to Cargo.toml
 
 ```toml
 [dependencies]
-elasticsearch-dsl = "0.1"
+elasticsearch-dsl = "0.2"
 ```
 
 ## Documentation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! elasticsearch-dsl = "0.1"
+//! elasticsearch-dsl = "0.2"
 //! ```
 //!
 //! ## Documentation


### PR DESCRIPTION
Query DSL is almost complete, only span queries remain, it's fine to bump the minor version and release 0.2.00