### PR TITLE
Allow passing any structure to percolator query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/src/search/queries/params/percolate_query.rs
+++ b/src/search/queries/params/percolate_query.rs
@@ -11,24 +11,6 @@ pub enum PercolateSource {
     Documents(Vec<serde_json::Value>),
 }
 
-impl From<serde_json::Value> for PercolateSource {
-    fn from(document: serde_json::Value) -> Self {
-        Self::Document(document)
-    }
-}
-
-impl From<Vec<serde_json::Value>> for PercolateSource {
-    fn from(documents: Vec<serde_json::Value>) -> Self {
-        Self::Documents(documents)
-    }
-}
-
-impl<const N: usize> From<[serde_json::Value; N]> for PercolateSource {
-    fn from(value: [serde_json::Value; N]) -> Self {
-        Self::Documents(value.to_vec())
-    }
-}
-
 impl ShouldSkip for PercolateSource {
     fn should_skip(&self) -> bool {
         match self {


### PR DESCRIPTION
This should simplify DSL and would not require creating Value manually.

cc @vinted/boost 