### PR TITLE
fix highlight order null serde

### DIFF
--- a/src/search/highlight/mod.rs
+++ b/src/search/highlight/mod.rs
@@ -164,5 +164,31 @@ mod tests {
                 ]
             }),
         );
+
+        assert_serialize(
+            Highlight::new()
+                .highlighter(
+                    Highlighter::new()
+                        .tags((["<eim>"], ["</eim>"]))
+                        .fvh()
+                        .matched_fields(["one", "two", "three"])
+                        .order(Order::Score),
+                )
+                .field("field1")
+                .field("field2")
+                .field_highlighter("field3", Highlighter::new().plain().no_match_size(2u32)),
+            json!({
+                "pre_tags": ["<eim>"],
+                "post_tags": ["</eim>"],
+                "matched_fields": ["one", "two", "three"],
+                "order": "score",
+                "type": "fvh",
+                "fields": [
+                    { "field1": {} },
+                    { "field2": {} },
+                    { "field3": { "type": "plain", "no_match_size": 2 } },
+                ]
+            }),
+        );
     }
 }

--- a/src/search/highlight/order.rs
+++ b/src/search/highlight/order.rs
@@ -6,7 +6,7 @@
 /// [How highlighters work internally](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#how-es-highlighters-work-internally)
 /// for more details how different highlighters find the best fragments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(untagged, rename_all = "lowercase")]
+#[serde(rename_all = "lowercase")]
 pub enum Order {
     /// Sorts highlighted fragments by score.
     Score,


### PR DESCRIPTION
When using highlight's `order(Order)`, the output json gives `null` no matter what order is actually set.
Try to fix this by removing the `untagged` from `Order`.