### PR TITLE
fix: add filter agg to aggregation macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/src/search/aggregations/mod.rs
+++ b/src/search/aggregations/mod.rs
@@ -28,7 +28,7 @@ macro_rules! aggregation {
         /// A container enum for supported Elasticsearch query types
         #[derive(Debug, Clone, PartialEq, Serialize)]
         #[serde(untagged)]
-        #[allow(missing_docs)]
+        #[allow(missing_docs, clippy::large_enum_variant)]
         pub enum Aggregation {
             $(
                 $variant($query),

--- a/src/search/aggregations/mod.rs
+++ b/src/search/aggregations/mod.rs
@@ -55,6 +55,7 @@ aggregation!(
     Sum(SumAggregation),
     Rate(RateAggregation),
     Sampler(SamplerAggregation),
+    Filter(FilterAggregation),
     DiversifiedSampler(DiversifiedSamplerAggregation)
 );
 


### PR DESCRIPTION
Probably was missing in yesterdays commit.

@buinauskas 