### PR TITLE
Remove cloning from Query PartialEq impl

### DIFF
--- a/src/search/queries/mod.rs
+++ b/src/search/queries/mod.rs
@@ -88,13 +88,19 @@ macro_rules! query {
 
             impl PartialEq<$query> for Query {
                 fn eq(&self, other: &$query) -> bool {
-                    self.eq(&Query::from(other.clone()))
+                    match self {
+                        Query::$variant(query) => query.eq(other),
+                        _ => false,
+                    }
                 }
             }
 
             impl PartialEq<Query> for $query {
                 fn eq(&self, other: &Query) -> bool {
-                    Query::from(self.clone()).eq(other)
+                    match other {
+                        Query::$variant(query) => self.eq(query),
+                        _ => false,
+                    }
                 }
             }
 


### PR DESCRIPTION
It's more efficient to match than to clone a query just for comparison.