### PR TITLE
Overwrite debug implementations for leaf structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.3.6"
+version = "0.3.7"
 authors = ["Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/src/search/params/date.rs
+++ b/src/search/params/date.rs
@@ -5,7 +5,7 @@ use std::time::SystemTime;
 pub type ChronoTime = DateTime<Utc>;
 
 /// Time variants to serialize
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Clone, Copy, Serialize)]
 #[serde(untagged)]
 pub enum Date {
     /// System time
@@ -13,6 +13,15 @@ pub enum Date {
 
     /// Chrono time
     Chrono(ChronoTime),
+}
+
+impl std::fmt::Debug for Date {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::System(value) => value.fmt(f),
+            Self::Chrono(value) => value.fmt(f),
+        }
+    }
 }
 
 impl From<SystemTime> for Date {

--- a/src/search/params/number.rs
+++ b/src/search/params/number.rs
@@ -1,10 +1,10 @@
 use std::cmp::Ordering;
 
 /// Numeric enum
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Number(N);
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 #[serde(untagged)]
 enum N {
     /// Non-negative integers
@@ -18,6 +18,17 @@ enum N {
 
     /// 64-bit floats
     F64(f64),
+}
+
+impl std::fmt::Debug for Number {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            N::Pos(value) => value.fmt(f),
+            N::Neg(value) => value.fmt(f),
+            N::F32(value) => value.fmt(f),
+            N::F64(value) => value.fmt(f),
+        }
+    }
 }
 
 impl std::fmt::Display for Number {

--- a/src/search/params/term.rs
+++ b/src/search/params/term.rs
@@ -4,10 +4,10 @@ use chrono::{DateTime, Utc};
 use std::time::SystemTime;
 
 /// Leaf term value
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct Term(Option<Inner>);
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(untagged)]
 enum Inner {
     /// Boolean value
@@ -21,6 +21,26 @@ enum Inner {
 
     /// Date
     Date(Date),
+}
+
+impl std::fmt::Debug for Term {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.0 {
+            Some(value) => value.fmt(f),
+            None => "None".fmt(f),
+        }
+    }
+}
+
+impl std::fmt::Debug for Inner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bool(value) => value.fmt(f),
+            Self::String(value) => value.fmt(f),
+            Self::Number(value) => value.fmt(f),
+            Self::Date(value) => value.fmt(f),
+        }
+    }
 }
 
 impl From<bool> for Term {

--- a/src/search/params/terms.rs
+++ b/src/search/params/terms.rs
@@ -2,8 +2,14 @@ use super::*;
 use crate::util::*;
 
 /// A collection of terms
-#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, PartialEq, PartialOrd, Serialize)]
 pub struct Terms(std::collections::BTreeSet<Term>);
+
+impl std::fmt::Debug for Terms {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl<T> From<T> for Terms
 where

--- a/src/search/params/text.rs
+++ b/src/search/params/text.rs
@@ -2,8 +2,14 @@ use crate::util::*;
 use std::borrow::Cow;
 
 /// Search text
-#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[derive(Default, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct Text(Option<String>);
+
+impl std::fmt::Debug for Text {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl ShouldSkip for Text {
     fn should_skip(&self) -> bool {

--- a/src/search/queries/params/boost.rs
+++ b/src/search/queries/params/boost.rs
@@ -5,8 +5,18 @@ use std::{cmp::Ordering, convert::TryFrom, fmt};
 const ERROR_MSG: &str = "Boost value cannot be negative";
 
 /// A container type for boost values
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Serialize)]
 pub struct Boost(Inner);
+
+impl fmt::Debug for Boost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.0 {
+            Inner::U64(value) => value.fmt(f),
+            Inner::F32(value) => value.fmt(f),
+            Inner::F64(value) => value.fmt(f),
+        }
+    }
+}
 
 impl fmt::Display for Boost {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/search/queries/params/negative_boost.rs
+++ b/src/search/queries/params/negative_boost.rs
@@ -2,12 +2,18 @@
 use std::{f32, fmt};
 
 /// A container type for boost values
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Serialize)]
 pub struct NegativeBoost(f32);
+
+impl fmt::Debug for NegativeBoost {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 impl fmt::Display for NegativeBoost {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.0)
+        self.0.fmt(f)
     }
 }
 

--- a/src/util/key_value_pair.rs
+++ b/src/util/key_value_pair.rs
@@ -1,6 +1,6 @@
 use serde::ser::{Serialize, SerializeMap, Serializer};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub(crate) struct KeyValuePair<K, V>
 where
     K: Serialize,
@@ -18,6 +18,16 @@ where
     /// Creates an instance of [`KeyValuePair`]
     pub(crate) fn new(key: K, value: V) -> Self {
         Self { key, value }
+    }
+}
+
+impl<K, V> std::fmt::Debug for KeyValuePair<K, V>
+where
+    K: Serialize + std::fmt::Debug,
+    V: Serialize + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_map().entry(&self.key, &self.value).finish()
     }
 }
 


### PR DESCRIPTION
Debug implementations have become nightmare to read, reimplement some of them manually for better readability.
