### PR TITLE
Add support for span queries

### DIFF
--- a/src/search/queries/mod.rs
+++ b/src/search/queries/mod.rs
@@ -183,6 +183,106 @@ query!(
     Wrapper(WrapperQuery),
     Script(ScriptQuery),
     ScriptScore(ScriptScoreQuery),
+    SpanContaining(SpanContainingQuery),
+    SpanFieldMasking(SpanFieldMaskingQuery),
+    SpanFirst(SpanFirstQuery),
+    SpanMulti(SpanMultiQuery),
+    SpanNear(SpanNearQuery),
+    SpanNot(SpanNotQuery),
+    SpanOr(SpanOrQuery),
+    SpanTerm(SpanTermQuery),
+    SpanWithin(SpanWithinQuery),
+);
+
+macro_rules! multi_term_query {
+    ($($variant:ident($query:ty)),+ $(,)?) => {
+        /// A container enum for supported Elasticsearch query types
+        #[derive(Clone, PartialEq, Serialize)]
+        #[serde(untagged)]
+        #[allow(missing_docs)]
+        pub enum MultiTermQuery {
+            $(
+                $variant($query),
+            )*
+        }
+
+        impl IntoIterator for MultiTermQuery {
+            type Item = Self;
+            type IntoIter = std::option::IntoIter<Self::Item>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                if self.should_skip() {
+                    None.into_iter()
+                } else {
+                    Some(self).into_iter()
+                }
+            }
+        }
+
+        impl ShouldSkip for MultiTermQuery {
+            fn should_skip(&self) -> bool {
+                match self {
+                    $(
+                        Self::$variant(q) => q.should_skip(),
+                    )+
+                }
+            }
+        }
+
+        impl std::fmt::Debug for MultiTermQuery {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    $(
+                        Self::$variant(q) => q.fmt(f),
+                    )+
+                }
+            }
+        }
+
+        $(
+            impl From<$query> for MultiTermQuery {
+                fn from(q: $query) -> Self {
+                    MultiTermQuery::$variant(q)
+                }
+            }
+
+            impl PartialEq<$query> for MultiTermQuery {
+                fn eq(&self, other: &$query) -> bool {
+                    match self {
+                        Self::$variant(query) => query.eq(other),
+                        _ => false,
+                    }
+                }
+            }
+
+            impl PartialEq<MultiTermQuery> for $query {
+                fn eq(&self, other: &MultiTermQuery) -> bool {
+                    match other {
+                        MultiTermQuery::$variant(query) => self.eq(query),
+                        _ => false,
+                    }
+                }
+            }
+
+            impl From<$query> for Option<MultiTermQuery> {
+                fn from(q: $query) -> Self {
+                    if q.should_skip() {
+                        None
+                    } else {
+                        Some(MultiTermQuery::$variant(q))
+                    }
+                }
+            }
+        )+
+    };
+}
+
+multi_term_query!(
+    Prefix(PrefixQuery),
+    Regexp(RegexpQuery),
+    Wildcard(WildcardQuery),
+    Range(RangeQuery),
+    Fuzzy(FuzzyQuery),
 );
 
 /// A collection of queries

--- a/src/search/queries/span/mod.rs
+++ b/src/search/queries/span/mod.rs
@@ -9,3 +9,136 @@
 //! spans.
 //!
 //! Span queries cannot be mixed with non-span queries (with the exception of the span_multi query).
+
+mod span_containing_query;
+mod span_field_masking;
+mod span_first;
+mod span_multi;
+mod span_near;
+mod span_not;
+mod span_or;
+mod span_term;
+mod span_within;
+
+pub use span_containing_query::*;
+pub use span_field_masking::*;
+pub use span_first::*;
+pub use span_multi::*;
+pub use span_near::*;
+pub use span_not::*;
+pub use span_or::*;
+pub use span_term::*;
+pub use span_within::*;
+use crate::Query;
+use crate::util::ShouldSkip;
+
+macro_rules! span_query {
+    ($($variant:ident($query:ty)),+ $(,)?) => {
+        /// A container enum for supported Elasticsearch query types
+        #[derive(Clone, PartialEq, Serialize)]
+        #[serde(untagged)]
+        #[allow(missing_docs)]
+        pub enum SpanQuery {
+            $(
+                $variant($query),
+            )*
+        }
+
+        impl IntoIterator for SpanQuery {
+            type Item = Self;
+            type IntoIter = std::option::IntoIter<Self::Item>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                if self.should_skip() {
+                    None.into_iter()
+                } else {
+                    Some(self).into_iter()
+                }
+            }
+        }
+
+        impl ShouldSkip for SpanQuery {
+            fn should_skip(&self) -> bool {
+                match self {
+                    $(
+                        Self::$variant(q) => q.should_skip(),
+                    )+
+                }
+            }
+        }
+
+        impl std::fmt::Debug for SpanQuery {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                match self {
+                    $(
+                        Self::$variant(q) => q.fmt(f),
+                    )+
+                }
+            }
+        }
+
+        $(
+            impl From<$query> for SpanQuery {
+                fn from(q: $query) -> Self {
+                    SpanQuery::$variant(q)
+                }
+            }
+
+            impl PartialEq<$query> for SpanQuery {
+                fn eq(&self, other: &$query) -> bool {
+                    match self {
+                        Self::$variant(query) => query.eq(other),
+                        _ => false,
+                    }
+                }
+            }
+
+            impl PartialEq<SpanQuery> for $query {
+                fn eq(&self, other: &SpanQuery) -> bool {
+                    match other {
+                        SpanQuery::$variant(query) => self.eq(query),
+                        _ => false,
+                    }
+                }
+            }
+
+            impl From<$query> for Option<SpanQuery> {
+                fn from(q: $query) -> Self {
+                    if q.should_skip() {
+                        None
+                    } else {
+                        Some(SpanQuery::$variant(q))
+                    }
+                }
+            }
+        )+
+    };
+}
+
+span_query!(
+    SpanContaining(SpanContainingQuery),
+    SpanFieldMasking(SpanFieldMaskingQuery),
+    SpanFirst(SpanFirstQuery),
+    SpanMulti(SpanMultiQuery),
+    SpanNear(SpanNearQuery),
+    SpanNot(SpanNotQuery),
+    SpanOr(SpanOrQuery),
+    SpanTerm(SpanTermQuery),
+    SpanWithin(SpanWithinQuery),
+);
+
+impl Into<Query> for SpanQuery {
+    fn into(self) -> Query {
+        match self {
+            SpanQuery::SpanContaining(q) => Query::SpanContaining(q),
+            SpanQuery::SpanFieldMasking(q) => Query::SpanFieldMasking(q),
+            SpanQuery::SpanFirst(q) => Query::SpanFirst(q),
+            SpanQuery::SpanMulti(q) => Query::SpanMulti(q),
+            SpanQuery::SpanNear(q) => Query::SpanNear(q),
+            SpanQuery::SpanNot(q) => Query::SpanNot(q),
+            SpanQuery::SpanOr(q) => Query::SpanOr(q),
+            SpanQuery::SpanTerm(q) => Query::SpanTerm(q),
+            SpanQuery::SpanWithin(q) => Query::SpanWithin(q),
+        }
+    }
+}

--- a/src/search/queries/span/span_containing_query.rs
+++ b/src/search/queries/span/span_containing_query.rs
@@ -1,0 +1,92 @@
+use crate::util::*;
+use crate::{Query, SpanQuery};
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SpanContainingQuery {
+    #[serde(rename = "span_containing")]
+    inner: Inner,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Inner {
+    little: Box<SpanQuery>,
+    big: Box<SpanQuery>,
+}
+
+impl ShouldSkip for SpanContainingQuery {}
+
+impl Query {
+    /// Creates an instance of [`SpanContainingQuery`]
+    #[allow(unused)]
+    pub fn span_containing<L, B>(little: L, big: B) -> SpanContainingQuery
+    where
+        L: Into<SpanQuery>,
+        B: Into<SpanQuery>,
+    {
+        SpanContainingQuery {
+            inner: Inner {
+                little: Box::new(little.into()),
+                big: Box::new(big.into()),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        assert_serialize(
+            Query::span_containing(
+                SpanQuery::SpanTerm(Query::span_term("little", "1324")),
+                SpanQuery::SpanTerm(Query::span_term("big", "4321")),
+            ),
+            json!({
+                "span_containing": {
+                    "little": {
+                        "span_term": {
+                            "little": {
+                                "value": "1324"
+                            }
+                        }
+                    },
+                    "big": {
+                        "span_term": {
+                            "big": {
+                                "value": "4321"
+                            }
+                        }
+                    }
+                }
+            }),
+        );
+
+        assert_serialize(
+            Query::span_containing(
+                SpanQuery::SpanTerm(Query::span_term("little", "1324")),
+                SpanQuery::SpanTerm(Query::span_term("big", "4321")),
+            ),
+            json!({
+                "span_containing": {
+                    "little": {
+                        "span_term": {
+                            "little": {
+                                "value": "1324"
+                            }
+                        }
+                    },
+                    "big": {
+                        "span_term": {
+                            "big": {
+                                "value": "4321"
+                            }
+                        }
+                    }
+                }
+            }),
+        );
+    }
+}

--- a/src/search/queries/span/span_field_masking.rs
+++ b/src/search/queries/span/span_field_masking.rs
@@ -1,0 +1,119 @@
+use crate::util::*;
+use crate::{Query, SpanQuery};
+
+/// Wrapper to allow span queries to participate in composite single-field span queries by lying about their search field. The span field masking query maps to Lucene’s SpanFieldMaskingQuery
+///
+/// This can be used to support queries like span-near or span-or across different fields, which is not ordinarily permitted.
+///
+/// Span field masking query is invaluable in conjunction with multi-fields when same content is indexed with multiple analyzers. For instance we could index a field with the standard analyzer which breaks text up into words, and again with the english analyzer which stems words into their root form.
+///
+/// Example:
+///
+/// ```http
+/// GET /_search
+/// {
+///   "query": {
+///     "span_near": {
+///       "clauses": [
+///         {
+///           "span_term": {
+///             "text": "quick brown"
+///           }
+///         },
+///         {
+///           "span_field_masking": {
+///             "query": {
+///               "span_term": {
+///                 "text.stems": "fox"
+///               }
+///             },
+///             "field": "text"
+///           }
+///         }
+///       ],
+///       "slop": 5,
+///       "in_order": false
+///     }
+///   }
+/// }
+/// ```
+///
+/// Note: as span field masking query returns the masked field, scoring will be done using the norms of the field name supplied. This may lead to unexpected scoring behaviour.
+///
+/// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-span-field-masking-query.html>
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SpanFieldMaskingQuery {
+    #[serde(rename = "span_field_masking")]
+    inner: Inner,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Inner {
+    query: Box<SpanQuery>,
+    field: String,
+}
+
+impl ShouldSkip for SpanFieldMaskingQuery {}
+
+impl Query {
+    /// Creates an instance of [`SpanFieldMaskingQuery`]
+    #[allow(unused)]
+    pub fn span_field_masking<Q, F>(query: Q, field: F) -> SpanFieldMaskingQuery
+    where
+        Q: Into<SpanQuery>,
+        F: Into<String>,
+    {
+        SpanFieldMaskingQuery {
+            inner: Inner {
+                query: Box::new(query.into()),
+                field: field.into(),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        assert_serialize(
+            Query::span_field_masking(
+                SpanQuery::SpanTerm(Query::span_term("test", 1234u32)),
+                "test".to_string(),
+            ),
+            json!({
+                "span_field_masking": {
+                    "query": {
+                        "span_term": {
+                            "test": {
+                                "value": 1234
+                            }
+                        }
+                    },
+                    "field": "test"
+                }
+            }),
+        );
+
+        assert_serialize(
+            Query::span_field_masking(
+                SpanQuery::SpanTerm(Query::span_term("test", 1234u32)),
+                "test".to_string(),
+            ),
+            json!({
+                "span_field_masking": {
+                    "query": {
+                        "span_term": {
+                            "test": {
+                                "value": 1234
+                            }
+                        }
+                    },
+                    "field": "test"
+                }
+            }),
+        );
+    }
+}

--- a/src/search/queries/span/span_first.rs
+++ b/src/search/queries/span/span_first.rs
@@ -1,0 +1,80 @@
+use crate::util::*;
+use crate::{Query, SpanQuery};
+use serde::Serialize;
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SpanFirstQuery {
+    #[serde(rename = "span_first")]
+    inner: Inner,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Inner {
+    r#match: Box<SpanQuery>,
+    end: i32,
+}
+
+impl ShouldSkip for SpanFirstQuery {}
+
+impl Query {
+    /// Creates an instance of [`SpanFirstQuery`]
+    #[allow(unused)]
+    pub fn span_first<Q>(r#match: Q, end: i32) -> SpanFirstQuery
+    where
+        Q: Into<SpanQuery>,
+    {
+        SpanFirstQuery {
+            inner: Inner {
+                r#match: Box::new(r#match.into()),
+                end,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        assert_serialize(
+            Query::span_first(
+                SpanQuery::SpanTerm(Query::span_term("test", 1234u32)),
+                10i32,
+            ),
+            json!({
+                "span_first": {
+                    "match": {
+                        "span_term": {
+                            "test": {
+                                "value": 1234
+                            }
+                        }
+                    },
+                    "end": 10
+                }
+            }),
+        );
+
+        assert_serialize(
+            Query::span_first(
+                SpanQuery::SpanTerm(Query::span_term("test", 1234u32)),
+                10i32,
+            ),
+            json!({
+                "span_first": {
+                    "match": {
+                        "span_term": {
+                            "test": {
+                                "value": 1234
+                            }
+                        }
+                    },
+                    "end": 10
+                }
+            }),
+        );
+    }
+}

--- a/src/search/queries/span/span_multi.rs
+++ b/src/search/queries/span/span_multi.rs
@@ -1,0 +1,72 @@
+use crate::util::*;
+use crate::{MultiTermQuery, Query};
+use serde::Serialize;
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SpanMultiQuery {
+    #[serde(rename = "span_multi")]
+    inner: Inner,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Inner {
+    r#match: Box<MultiTermQuery>,
+}
+
+impl ShouldSkip for SpanMultiQuery {}
+
+impl Query {
+    /// Creates an instance of [`SpanMultiQuery`]
+    #[allow(unused)]
+    pub fn span_multi<Q>(r#match: Q) -> SpanMultiQuery
+        where Q: Into<MultiTermQuery>{
+        SpanMultiQuery {
+            inner: Inner {
+                r#match: Box::new(r#match.into()),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        assert_serialize(
+            Query::span_multi(MultiTermQuery::Prefix(Query::prefix(
+                "test", "1234",
+            ))),
+            json!({
+                "span_multi": {
+                    "match" : {
+                        "prefix": {
+                            "test": {
+                                "value": "1234"
+                            }
+                        }
+                    }
+                }
+            }),
+        );
+
+        assert_serialize(
+            Query::span_multi(MultiTermQuery::Prefix(Query::prefix(
+                "test", "1234",
+            ))),
+            json!({
+                "span_multi": {
+                    "match" : {
+                        "prefix": {
+                            "test": {
+                                "value": "1234"
+                            }
+                        }
+                    }
+                }
+            }),
+        );
+    }
+}

--- a/src/search/queries/span/span_near.rs
+++ b/src/search/queries/span/span_near.rs
@@ -1,0 +1,103 @@
+use crate::util::*;
+use crate::Query;
+use serde::Serialize;
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SpanNearQuery {
+    #[serde(rename = "span_near")]
+    inner: Inner,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Inner {
+    clauses: Vec<Query>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    in_order: Option<bool>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    slop: Option<i32>,
+}
+
+impl ShouldSkip for SpanNearQuery {
+    fn should_skip(&self) -> bool {
+        self.inner.clauses.should_skip()
+    }
+}
+
+impl Query {
+    /// Creates an instance of [`SpanNearQuery`]
+    #[allow(unused)]
+    pub fn span_near(clauses: Vec<Query>) -> SpanNearQuery {
+        SpanNearQuery {
+            inner: Inner {
+                clauses,
+                in_order: None,
+                slop: None,
+            },
+        }
+    }
+}
+
+impl SpanNearQuery {
+    /// TODO
+    pub fn in_order(mut self, in_order: bool) -> Self {
+        self.inner.in_order = Some(in_order);
+        self
+    }
+
+    /// TODO
+    pub fn slop(mut self, slop: i32) -> Self {
+        self.inner.slop = Some(slop);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        assert_serialize(
+            Query::span_near(
+                vec![Query::Term(Query::term("test", 1234u32))],
+            ),
+            json!({
+                "span_near": {
+                    "clauses": [
+                        {
+                            "term": {
+                                "test": {
+                                    "value": 1234
+                                }
+                            }
+                        }
+                    ]
+                }
+            }),
+        );
+
+        assert_serialize(
+            Query::span_near(
+                vec![Query::Term(Query::term("test", 1234u32))],
+            ).in_order(true).slop(4321),
+            json!({
+                "span_near": {
+                    "clauses": [
+                        {
+                            "term": {
+                                "test": {
+                                    "value": 1234
+                                }
+                            }
+                        }
+                    ],
+                    "in_order": true,
+                    "slop": 4321
+                }
+            }),
+        );
+    }
+}

--- a/src/search/queries/span/span_not.rs
+++ b/src/search/queries/span/span_not.rs
@@ -1,0 +1,147 @@
+use crate::util::*;
+use crate::{Query, SpanQuery};
+use serde::Serialize;
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SpanNotQuery {
+    #[serde(rename = "span_not")]
+    inner: Inner,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Inner {
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    dist: Option<i32>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    exclude: Vec<SpanQuery>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    include: Vec<SpanQuery>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    post: Option<i32>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    pre: Option<i32>,
+}
+
+impl ShouldSkip for SpanNotQuery {}
+
+impl Query {
+    /// Creates an instance of [`SpanNotQuery`]
+    #[allow(unused)]
+    pub fn span_not(
+        exclude: Vec<SpanQuery>,
+        include: Vec<SpanQuery>,
+    ) -> SpanNotQuery {
+        SpanNotQuery {
+            inner: Inner {
+                dist: None,
+                exclude,
+                include,
+                post: None,
+                pre: None,
+            },
+        }
+    }
+}
+
+impl SpanNotQuery {
+    /// TODO
+    fn dist(mut self, dist: i32) -> Self {
+        self.inner.dist = Some(dist);
+        self
+    }
+
+    /// TODO
+    fn post(mut self, post: i32) -> Self {
+        self.inner.post = Some(post);
+        self
+    }
+
+    /// TODO
+    fn pre(mut self, pre: i32) -> Self {
+        self.inner.pre = Some(pre);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        assert_serialize(
+            Query::span_not(
+                Some(1234),
+                vec![SpanQuery::SpanTerm(Query::span_term("foo", 1234u32))],
+                vec![SpanQuery::SpanTerm(Query::span_term("bar", 4321u32))],
+                Some(4321),
+                Some(5678),
+            ),
+            json!({
+                "span_not": {
+                    "dist": 1234,
+                    "exclude": [
+                        {
+                            "span_term": {
+                                "foo": {
+                                    "value": 1234
+                                }
+                            }
+                        }
+                    ],
+                    "include": [
+                        {
+                            "span_term": {
+                                "bar": {
+                                    "value": 4321
+                                }
+                            }
+                        }
+                    ],
+                    "post": 4321,
+                    "pre": 5678
+                }
+            }),
+        );
+
+        assert_serialize(
+            Query::span_not(
+                Some(1234),
+                vec![SpanQuery::SpanTerm(Query::span_term("foo", 1234u32))],
+                vec![SpanQuery::SpanTerm(Query::span_term("bar", 4321u32))],
+                Some(4321),
+                Some(5678),
+            ),
+            json!({
+                "span_not": {
+                    "dist": 1234,
+                    "exclude": [
+                        {
+                            "span_term": {
+                                "foo": {
+                                    "value": 1234
+                                }
+                            }
+                        }
+                    ],
+                    "include": [
+                        {
+                            "span_term": {
+                                "bar": {
+                                    "value": 4321
+                                }
+                            }
+                        }
+                    ],
+                    "post": 4321,
+                    "pre": 5678
+                }
+            }),
+        );
+    }
+}

--- a/src/search/queries/span/span_or.rs
+++ b/src/search/queries/span/span_or.rs
@@ -1,0 +1,73 @@
+use crate::util::*;
+use crate::{Query, SpanQuery};
+use serde::Serialize;
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SpanOrQuery {
+    #[serde(rename = "span_or")]
+    inner: Inner,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Inner {
+    clauses: Vec<SpanQuery>,
+}
+
+impl ShouldSkip for SpanOrQuery {}
+
+impl Query {
+    /// Creates an instance of [`SpanOrQuery`]
+    #[allow(unused)]
+    pub fn span_or(clauses: Vec<SpanQuery>) -> SpanOrQuery {
+        SpanOrQuery {
+            inner: Inner { clauses },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        assert_serialize(
+            Query::span_or(vec![SpanQuery::SpanTerm(Query::span_term(
+                "test", 1234u32,
+            ))]),
+            json!({
+                "span_or": {
+                    "clauses": [
+                        {
+                            "span_term": {
+                                "test": {
+                                    "value": 1234
+                                }
+                            }
+                        }
+                    ]
+                }
+            }),
+        );
+
+        assert_serialize(
+            Query::span_or(vec![SpanQuery::SpanTerm(Query::span_term(
+                "test", 1234u32,
+            ))]),
+            json!({
+                "span_or": {
+                    "clauses": [
+                        {
+                            "span_term": {
+                                "test": {
+                                    "value": 1234
+                                }
+                            }
+                        }
+                    ]
+                }
+            }),
+        );
+    }
+}

--- a/src/search/queries/span/span_term.rs
+++ b/src/search/queries/span/span_term.rs
@@ -1,0 +1,97 @@
+use crate::util::*;
+use crate::{Boost, Query, Term};
+use serde::ser::{Serialize, SerializeMap, Serializer};
+
+/// TODO
+#[derive(Debug, Clone, PartialEq)]
+pub struct SpanTermQuery {
+    field: String,
+    inner: Inner,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Inner {
+    value: Term,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    boost: Option<Boost>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    _name: Option<String>,
+}
+
+impl Query {
+    /// Creates an instance of [`SpanTermQuery`]
+    ///
+    /// - `field` - Field you wish to search.
+    /// - `value` - Term you wish to find in the provided field.
+    /// To return a document, the term must exactly match the field value, including whitespace and capitalization.
+    pub fn span_term(field: impl Into<String>, value: impl Into<Term>) -> SpanTermQuery {
+        SpanTermQuery {
+            field: field.into(),
+            inner: Inner {
+                value: value.into(),
+                boost: None,
+                _name: None,
+            },
+        }
+    }
+}
+
+impl SpanTermQuery {
+    add_boost_and_name!();
+}
+
+impl ShouldSkip for SpanTermQuery {
+    fn should_skip(&self) -> bool {
+        self.inner.value.should_skip()
+    }
+}
+
+impl Serialize for SpanTermQuery {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut hash = std::collections::HashMap::new();
+        let _ = hash.insert(&self.field, &self.inner);
+
+        let mut map = serializer.serialize_map(Some(1))?;
+        map.serialize_entry("span_term", &hash)?;
+        map.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        assert_serialize(
+            Query::span_term("test", 123u32),
+            json!({
+                "span_term": {
+                    "test": {
+                        "value": 123u32
+                    }
+                }
+            }),
+        );
+
+        assert_serialize(
+            Query::span_term("test", 123u32)
+                .boost(2u32)
+                .name("test"),
+            json!({
+                "span_term": {
+                    "test": {
+                        "value": 123u32,
+                        "boost": 2u32,
+                        "_name": "test"
+                    }
+                }
+            }),
+        );
+    }
+}

--- a/src/search/queries/span/span_within.rs
+++ b/src/search/queries/span/span_within.rs
@@ -1,0 +1,89 @@
+use crate::util::*;
+use crate::{Query, SpanQuery};
+use serde::Serialize;
+
+/// TODO
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct SpanWithinQuery {
+    #[serde(rename = "span_within")]
+    inner: Inner,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+struct Inner {
+    big: Box<SpanQuery>,
+    little: Box<SpanQuery>,
+}
+
+impl ShouldSkip for SpanWithinQuery {}
+
+impl Query {
+    /// Creates an instance of [`SpanContainingQuery`]
+    #[allow(unused)]
+    pub fn span_within(little: impl Into<SpanQuery>, big: impl Into<SpanQuery>) -> SpanWithinQuery {
+        SpanWithinQuery {
+            inner: Inner {
+                little: Box::new(little.into()),
+                big: Box::new(big.into()),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialization() {
+        assert_serialize(
+            Query::span_within(
+                SpanQuery::SpanTerm(Query::span_term("little", 1234u32)),
+                SpanQuery::SpanTerm(Query::span_term("big", 4321u32)),
+            ),
+            json!({
+                "span_within": {
+                    "little": {
+                        "span_term": {
+                            "little": {
+                                "value": 1234
+                            }
+                        }
+                    },
+                    "big": {
+                        "span_term": {
+                            "big": {
+                                "value": 4321
+                            }
+                        }
+                    }
+                }
+            }),
+        );
+
+        assert_serialize(
+            Query::span_within(
+                SpanQuery::SpanTerm(Query::span_term("little", 1234u32)),
+                SpanQuery::SpanTerm(Query::span_term("big", 4321u32)),
+            ),
+            json!({
+                "span_within": {
+                    "little": {
+                        "span_term": {
+                            "little": {
+                                "value": 1234
+                            }
+                        }
+                    },
+                    "big": {
+                        "span_term": {
+                            "big": {
+                                "value": 4321
+                            }
+                        }
+                    }
+                }
+            }),
+        );
+    }
+}

--- a/src/search/queries/term_level/regexp_query.rs
+++ b/src/search/queries/term_level/regexp_query.rs
@@ -61,8 +61,8 @@ impl Query {
     /// using the
     /// [`index.max_regex_length`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-regex-length) setting.
     pub fn regexp<S>(field: S, value: S) -> RegexpQuery
-    where
-        S: Into<String>,
+        where
+            S: Into<String>,
     {
         RegexpQuery {
             field: field.into(),


### PR DESCRIPTION
Adds support for Elasticsearch's span queries, https://www.elastic.co/guide/en/elasticsearch/reference/current/span-queries.html

This PR is still a work-in-progress.

Closes #100