### PR TITLE
Allow handling multiple inner hits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = ["examples/*"]
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = { version = "1" }
+serde_json = { version = "1", features = ["raw_value"] }
 
 [dev-dependencies]
 pretty_assertions = { version = "1" }


### PR DESCRIPTION
Elasticsearch can return multiple keyed inner hits, not just one under the `items` key.

This changes inner hits from Option[InnerHit] to a map of key/inner_hit pairs and defers value deserialization by using serde_json's RawValue. They will be deserialized on demand.