### PR TITLE
Revert "Allow handling multiple inner hits"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = ["examples/*"]
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = { version = "1", features = ["raw_value"] }
+serde_json = { version = "1" }
 
 [dev-dependencies]
 pretty_assertions = { version = "1" }


### PR DESCRIPTION
Reverts vinted/elasticsearch-dsl-rs#143

Will handle this in a larger PR covering the whole _source field.