### PR TITLE
Defer document source deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = ["examples/*"]
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
-serde_json = { version = "1" }
+serde_json = { version = "1", features = ["raw_value"] }
 
 [dev-dependencies]
 pretty_assertions = { version = "1" }


### PR DESCRIPTION
There are several problems that this change fixes/adjusts:
- reduced required typing, currently type for hit/inner hit always had to be specified
- switch to deferred source structure allows to skip expensive deserialization/serialization, this helps for large documents that only need to be transferred over the wire, if one wants to deserialize data, this can be done using the `.source()` method on the hit
- inner hits were incorrectly modeled, there can be many inner hits and `items` was something we've used in our domain that was carried over, inner hits are a map of key/value pairs, where the key is the hit name, and value is the inner hit

cc @ernestas-vinted  @vinted/boost please review this