### PR TITLE
Allow deeply nested Nested structures

### DIFF
--- a/src/search/queries/compound/function_score_query.rs
+++ b/src/search/queries/compound/function_score_query.rs
@@ -81,7 +81,7 @@ impl FunctionScoreQuery {
         let function = function.into();
 
         if let Some(function) = function {
-            let _ = self.inner.functions.push(function);
+            self.inner.functions.push(function);
         }
 
         self

--- a/src/search/response.rs
+++ b/src/search/response.rs
@@ -258,6 +258,10 @@ pub struct Nested {
 
     /// Offset
     pub offset: u64,
+
+    /// Nested document metadata
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip", rename = "_nested")]
+    pub nested: Option<Box<Nested>>,
 }
 
 /// Relation to total number of matched documents


### PR DESCRIPTION
As per docs, nested hits can be deeply nested https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html#hierarchical-nested-inner-hits.

Reflect this in search response.