### PR TITLE
Implement dedicated query serialization tester

### DIFF
--- a/src/search/queries/compound/bool_query.rs
+++ b/src/search/queries/compound/bool_query.rs
@@ -135,9 +135,9 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(Query::bool(), json!({ "bool": {} }));
+        assert_serialize_query(Query::bool(), json!({ "bool": {} }));
 
-        assert_serialize(
+        assert_serialize_query(
             Query::bool()
                 .must([Query::term("test1", 1), Query::term("test2", 2)])
                 .should([Query::term("test1", 3), Query::term("test2", 4)])
@@ -171,7 +171,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::bool()
                 .must(Query::term("test1", 1))
                 .must(Query::term("test2", 2))

--- a/src/search/queries/compound/boosting_query.rs
+++ b/src/search/queries/compound/boosting_query.rs
@@ -83,7 +83,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::boosting(Query::term("test1", 123), Query::term("test2", 456), 0.2),
             json!({
                 "boosting": {
@@ -106,7 +106,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::boosting(Query::term("test1", 123), Query::term("test2", 456), 0.2)
                 .boost(3)
                 .name("test"),

--- a/src/search/queries/compound/constant_score_query.rs
+++ b/src/search/queries/compound/constant_score_query.rs
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::constant_score(Query::term("test1", 123)),
             json!({
                 "constant_score": {
@@ -83,7 +83,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::constant_score(Query::term("test1", 123))
                 .boost(3)
                 .name("test"),

--- a/src/search/queries/compound/dis_max_query.rs
+++ b/src/search/queries/compound/dis_max_query.rs
@@ -107,7 +107,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::dis_max()
                 .query(Query::r#match("t1", "text"))
                 .query(Query::r#match("t2", "text")),
@@ -133,7 +133,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::dis_max().query([Query::r#match("t1", "text"), Query::r#match("t2", "text")]),
             json!({
                 "dis_max": {
@@ -157,7 +157,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::dis_max()
                 .query(Query::r#match("t1", "text"))
                 .query(Query::r#match("t2", "text"))

--- a/src/search/queries/compound/function_score_query.rs
+++ b/src/search/queries/compound/function_score_query.rs
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::function_score(Query::term("test", 1)).function(RandomScore::new()),
             json!({
                 "function_score": {
@@ -153,7 +153,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::function_score(Query::term("test", 1))
                 .function(RandomScore::new())
                 .function(Weight::new(2.0))

--- a/src/search/queries/custom/json_query.rs
+++ b/src/search/queries/custom/json_query.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::json(json!({ "term": { "user": "username" } })),
             json!({ "term": { "user": "username" } }),
         );

--- a/src/search/queries/full_text/combined_fields_query.rs
+++ b/src/search/queries/full_text/combined_fields_query.rs
@@ -134,7 +134,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::combined_fields(["test"], "search text"),
             json!({
                 "combined_fields": {
@@ -144,7 +144,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::combined_fields(["test"], "search text")
                 .auto_generate_synonyms_phrase_query(true)
                 .operator(Operator::And)

--- a/src/search/queries/full_text/match_bool_prefix_query.rs
+++ b/src/search/queries/full_text/match_bool_prefix_query.rs
@@ -124,7 +124,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::match_bool_prefix("test", "search text"),
             json!({
                 "match_bool_prefix": {
@@ -135,7 +135,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::match_bool_prefix("test", "search text")
                 .analyzer("search_time_analyzer")
                 .minimum_should_match("12")

--- a/src/search/queries/full_text/match_phrase_prefix_query.rs
+++ b/src/search/queries/full_text/match_phrase_prefix_query.rs
@@ -133,7 +133,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::match_phrase_prefix("test", "search text"),
             json!({
                 "match_phrase_prefix": {
@@ -144,7 +144,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::match_phrase_prefix("test", "search text")
                 .analyzer("search_time_analyzer")
                 .max_expansions(20)

--- a/src/search/queries/full_text/match_phrase_query.rs
+++ b/src/search/queries/full_text/match_phrase_query.rs
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::match_phrase("test", "search text"),
             json!({
                 "match_phrase": {
@@ -122,7 +122,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::match_phrase("test", "search text")
                 .analyzer("search_time_analyzer")
                 .slop(1u8)

--- a/src/search/queries/full_text/match_query.rs
+++ b/src/search/queries/full_text/match_query.rs
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::r#match("test", "search text"),
             json!({
                 "match": {
@@ -245,7 +245,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::r#match("test", "search text")
                 .analyzer("search_time_analyzer")
                 .auto_generate_synonyms_phrase_query(true)

--- a/src/search/queries/full_text/multi_match_query.rs
+++ b/src/search/queries/full_text/multi_match_query.rs
@@ -246,7 +246,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::multi_match(["test"], "search text"),
             json!({
                 "multi_match": {
@@ -256,7 +256,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::multi_match(["test"], "search text")
                 .r#type(MultiMatchQueryType::BestFields(
                     TieBreaker::try_from(0.2).ok(),

--- a/src/search/queries/full_text/query_string_query.rs
+++ b/src/search/queries/full_text/query_string_query.rs
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::query_string("search text"),
             json!({
                 "query_string": {
@@ -394,7 +394,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::query_string("search text")
                 .fields(["database"])
                 .default_operator(Operator::And)

--- a/src/search/queries/full_text/simple_query_string_query.rs
+++ b/src/search/queries/full_text/simple_query_string_query.rs
@@ -256,7 +256,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::simple_query_string("search text"),
             json!({
                 "simple_query_string": {
@@ -265,7 +265,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::simple_query_string("search text")
                 .fields(["database"])
                 .default_operator(Operator::And)

--- a/src/search/queries/geo/geo_bounding_box_query.rs
+++ b/src/search/queries/geo/geo_bounding_box_query.rs
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::geo_bounding_box(
                 "pin.location",
                 GeoBoundingBox::WellKnownText {
@@ -84,7 +84,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::geo_bounding_box(
                 "pin.location",
                 GeoBoundingBox::MainDiagonal {
@@ -112,7 +112,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::geo_bounding_box(
                 "pin.location",
                 GeoBoundingBox::Vertices {

--- a/src/search/queries/geo/geo_distance_query.rs
+++ b/src/search/queries/geo/geo_distance_query.rs
@@ -87,7 +87,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::geo_distance(
                 "pin.location",
                 GeoPoint::Coordinates {
@@ -104,7 +104,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::geo_distance(
                 "pin.location",
                 GeoPoint::Geohash("drm3btev3e86".into()),
@@ -118,7 +118,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::geo_distance(
                 "pin.location",
                 GeoPoint::Coordinates {

--- a/src/search/queries/geo/geo_shape_lookup_query.rs
+++ b/src/search/queries/geo/geo_shape_lookup_query.rs
@@ -147,7 +147,7 @@ mod tests {
 
     #[test]
     fn test_serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::geo_shape_lookup("pin.location", "id"),
             json!({
                 "geo_shape": {
@@ -160,7 +160,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::geo_shape_lookup("pin.location", "id")
                 .boost(2)
                 .name("test")

--- a/src/search/queries/geo/geo_shape_query.rs
+++ b/src/search/queries/geo/geo_shape_query.rs
@@ -101,7 +101,7 @@ mod tests {
 
     #[test]
     fn test_serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::geo_shape("pin.location", GeoShape::point([2.2, 1.1])),
             json!({
                 "geo_shape": {
@@ -115,7 +115,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::geo_shape("pin.location", GeoShape::point([2.2, 1.1]))
                 .boost(2)
                 .name("test")

--- a/src/search/queries/joining/has_child_query.rs
+++ b/src/search/queries/joining/has_child_query.rs
@@ -114,7 +114,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::has_child("child", Query::term("tag", "elasticsearch")),
             json!({
                 "has_child": {
@@ -130,7 +130,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::has_child("child", Query::term("tag", "elasticsearch"))
                 .boost(2)
                 .name("test")

--- a/src/search/queries/joining/has_parent_query.rs
+++ b/src/search/queries/joining/has_parent_query.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::has_parent("parent", Query::term("tag", "elasticsearch")),
             json!({
                 "has_parent": {
@@ -114,7 +114,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::has_parent("parent", Query::term("tag", "elasticsearch"))
                 .boost(2)
                 .name("test")

--- a/src/search/queries/joining/nested_query.rs
+++ b/src/search/queries/joining/nested_query.rs
@@ -144,7 +144,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::nested("vehicles", Query::term("vehicles.license", "ABC123")),
             json!({
                 "nested": {
@@ -160,7 +160,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::nested("vehicles", Query::term("vehicles.license", "ABC123"))
                 .boost(3)
                 .name("test"),
@@ -180,7 +180,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::nested(
                 "driver",
                 Query::nested(

--- a/src/search/queries/joining/parent_id_query.rs
+++ b/src/search/queries/joining/parent_id_query.rs
@@ -80,7 +80,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::parent_id("my-child", 1),
             json!({
                 "parent_id": {
@@ -90,7 +90,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::parent_id("my-child", 1)
                 .boost(2)
                 .name("test")

--- a/src/search/queries/match_all_query.rs
+++ b/src/search/queries/match_all_query.rs
@@ -49,9 +49,9 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(Query::match_all(), json!({ "match_all": {} }));
+        assert_serialize_query(Query::match_all(), json!({ "match_all": {} }));
 
-        assert_serialize(
+        assert_serialize_query(
             Query::match_all().boost(2).name("test"),
             json!({ "match_all": { "boost": 2, "_name": "test" } }),
         );

--- a/src/search/queries/match_none_query.rs
+++ b/src/search/queries/match_none_query.rs
@@ -49,9 +49,9 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(Query::match_none(), json!({"match_none": {} }));
+        assert_serialize_query(Query::match_none(), json!({"match_none": {} }));
 
-        assert_serialize(
+        assert_serialize_query(
             Query::match_none().boost(2).name("test"),
             json!({ "match_none": { "boost": 2, "_name": "test" } }),
         );

--- a/src/search/queries/mod.rs
+++ b/src/search/queries/mod.rs
@@ -183,6 +183,12 @@ query!(
     Wrapper(WrapperQuery),
     Script(ScriptQuery),
     ScriptScore(ScriptScoreQuery),
+    ParentId(ParentIdQuery),
+    HasParent(HasParentQuery),
+    HasChild(HasChildQuery),
+    SimpleQueryString(SimpleQueryStringQuery),
+    QueryString(QueryStringQuery),
+    CombinedFields(CombinedFieldsQuery),
 );
 
 /// A collection of queries

--- a/src/search/queries/shape/shape_lookup_query.rs
+++ b/src/search/queries/shape/shape_lookup_query.rs
@@ -139,7 +139,7 @@ mod tests {
 
     #[test]
     fn test_serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::shape_lookup("pin.location", "id"),
             json!({
                 "shape": {
@@ -152,7 +152,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::shape_lookup("pin.location", "id")
                 .boost(2)
                 .name("test")

--- a/src/search/queries/shape/shape_query.rs
+++ b/src/search/queries/shape/shape_query.rs
@@ -93,7 +93,7 @@ mod tests {
 
     #[test]
     fn test_serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::shape("pin.location", Shape::point([2.2, 1.1])),
             json!({
                 "shape": {
@@ -107,7 +107,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::shape("pin.location", Shape::point([2.2, 1.1]))
                 .boost(2)
                 .name("test")

--- a/src/search/queries/specialized/distance_feature_query.rs
+++ b/src/search/queries/specialized/distance_feature_query.rs
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::distance_feature("test", Utc.ymd(2014, 7, 8).and_hms(9, 1, 0), Time::Days(7)),
             json!({
                 "distance_feature": {
@@ -186,7 +186,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::distance_feature("test", Utc.ymd(2014, 7, 8).and_hms(9, 1, 0), Time::Days(7))
                 .boost(1.5)
                 .name("test"),
@@ -200,7 +200,7 @@ mod tests {
                 }
             }),
         );
-        assert_serialize(
+        assert_serialize_query(
             Query::distance_feature(
                 "test",
                 GeoPoint::coordinates(12.0, 13.0),
@@ -215,7 +215,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::distance_feature(
                 "test",
                 GeoPoint::coordinates(12.0, 13.0),

--- a/src/search/queries/specialized/more_like_this_query.rs
+++ b/src/search/queries/specialized/more_like_this_query.rs
@@ -361,7 +361,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::more_like_this(["test"]).fields(["title"]),
             json!({
                 "more_like_this": {
@@ -373,7 +373,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::more_like_this(["test"])
                 .fields(["title", "description"])
                 .min_term_freq(1)
@@ -393,7 +393,7 @@ mod tests {
                 }
             }),
         );
-        assert_serialize(
+        assert_serialize_query(
             Query::more_like_this([Document::new("123")]).fields(["title"]),
             json!({
                 "more_like_this": {
@@ -407,7 +407,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::more_like_this([Document::new("123")])
                 .fields(["title", "description"])
                 .min_term_freq(1)
@@ -429,7 +429,7 @@ mod tests {
                 }
             }),
         );
-        assert_serialize(
+        assert_serialize_query(
             Query::more_like_this([Like::from(Document::new("123")), Like::from("test")])
                 .fields(["title"]),
             json!({
@@ -445,7 +445,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::more_like_this([
                 Like::from(
                     Document::new("123")

--- a/src/search/queries/specialized/percolate_lookup_query.rs
+++ b/src/search/queries/specialized/percolate_lookup_query.rs
@@ -117,7 +117,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::percolate_lookup("field_name", "index_name", "document_id"),
             json!({
                 "percolate": {
@@ -128,7 +128,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::percolate_lookup("field_name", "index_name", "document_id")
                 .name("toast")
                 .routing("routing_value")

--- a/src/search/queries/specialized/percolate_query.rs
+++ b/src/search/queries/specialized/percolate_query.rs
@@ -96,7 +96,7 @@ mod tests {
             message: &'static str,
         }
 
-        assert_serialize(
+        assert_serialize_query(
             Query::percolate(
                 "field_name",
                 Source {
@@ -115,7 +115,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::percolate(
                 "field_name",
                 [Source {
@@ -136,7 +136,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::percolate("field_name", json!({"message": "lol"})),
             json!({
                 "percolate": {
@@ -148,7 +148,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::percolate("field_name", json!({"message": "lol"})).name("toast"),
             json!({
                 "percolate": {
@@ -161,7 +161,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::percolate("field_name", [json!({"message": "lol"})]),
             json!({
                 "percolate": {
@@ -175,7 +175,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::percolate("field_name", [json!({"message": "lol"})]).name("toast"),
             json!({
                 "percolate": {

--- a/src/search/queries/specialized/pinned_query.rs
+++ b/src/search/queries/specialized/pinned_query.rs
@@ -69,7 +69,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::pinned(PinnedQueryValues::ids([1]), Query::term("user_id", 2)),
             json!({
                 "pinned": {
@@ -85,7 +85,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::pinned(
                 PinnedQueryValues::docs([PinnedDocument::new("index", 1)]),
                 Query::term("user_id", 2),
@@ -104,7 +104,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::pinned(PinnedQueryValues::ids([1]), Query::term("user_id", 2))
                 .boost(2)
                 .name("test"),
@@ -124,7 +124,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::pinned(
                 PinnedQueryValues::docs([PinnedDocument::new("index", 1)]),
                 Query::term("user_id", 2),

--- a/src/search/queries/specialized/rank_feature_query.rs
+++ b/src/search/queries/specialized/rank_feature_query.rs
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::rank_feature("test"),
             json!({
                 "rank_feature": {
@@ -380,7 +380,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::rank_feature("test").boost(2).name("query"),
             json!({
                 "rank_feature": {
@@ -391,7 +391,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::rank_feature("test")
                 .saturation()
                 .boost(2)
@@ -406,7 +406,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::rank_feature("test")
                 .saturation()
                 .pivot(2.2)
@@ -424,7 +424,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::rank_feature("test")
                 .logarithm(2.2)
                 .boost(2)
@@ -441,7 +441,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::rank_feature("test")
                 .sigmoid(2.2, 3.3)
                 .boost(2)
@@ -459,7 +459,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::rank_feature("test").linear().boost(2).name("query"),
             json!({
                 "rank_feature": {

--- a/src/search/queries/specialized/script_query.rs
+++ b/src/search/queries/specialized/script_query.rs
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::script(
                 Script::source("doc['numberOfCommits'].value > params.param1").param("param1", 50),
             )

--- a/src/search/queries/specialized/script_score_query.rs
+++ b/src/search/queries/specialized/script_score_query.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::script_score(
                 Query::r#match("message", "elasticsearch"),
                 Script::source("doc['my-int'].value / 10"),

--- a/src/search/queries/specialized/wrapper_query.rs
+++ b/src/search/queries/specialized/wrapper_query.rs
@@ -49,7 +49,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::wrapper("eyJ0ZXJtIiA6IHsgInVzZXIuaWQiIDogImtpbWNoeSIgfX0="),
             json!({ "wrapper": { "query": "eyJ0ZXJtIiA6IHsgInVzZXIuaWQiIDogImtpbWNoeSIgfX0=" } }),
         );

--- a/src/search/queries/term_level/exists_query.rs
+++ b/src/search/queries/term_level/exists_query.rs
@@ -67,7 +67,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::exists("test"),
             json!({
                 "exists": {
@@ -76,7 +76,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::exists("test").boost(2).name("test"),
             json!({
                 "exists": {

--- a/src/search/queries/term_level/fuzzy_query.rs
+++ b/src/search/queries/term_level/fuzzy_query.rs
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::fuzzy("test", 123),
             json!({
                 "fuzzy": {
@@ -164,7 +164,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::fuzzy("test", 123)
                 .fuzziness(Fuzziness::Auto)
                 .max_expansions(3)
@@ -189,7 +189,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::bool().filter(Query::fuzzy("test", None::<String>)),
             json!({ "bool": {} }),
         )

--- a/src/search/queries/term_level/ids_query.rs
+++ b/src/search/queries/term_level/ids_query.rs
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::ids(vec![1, 3, 2, 5, 4, 6]),
             json!({
                 "ids": {
@@ -77,7 +77,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::ids(vec![1, 3, 2, 5, 4, 6]).boost(1.3).name("test"),
             json!({
                 "ids": {

--- a/src/search/queries/term_level/prefix_query.rs
+++ b/src/search/queries/term_level/prefix_query.rs
@@ -109,7 +109,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::prefix("test", 123),
             json!({
                 "prefix": {
@@ -120,7 +120,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::prefix("test", 123)
                 .rewrite(Rewrite::ConstantScore)
                 .case_insensitive(true)
@@ -139,7 +139,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::bool().filter(Query::prefix("test", None::<String>)),
             json!({ "bool": {} }),
         )

--- a/src/search/queries/term_level/range_query.rs
+++ b/src/search/queries/term_level/range_query.rs
@@ -170,7 +170,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::range("test_field"),
             json!({
                 "range": {
@@ -179,7 +179,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::range("test_field")
                 .gt(Option::<i32>::None)
                 .lt(Option::<i32>::None)
@@ -192,7 +192,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::range("test_numeric_field")
                 .gt(1)
                 .gte(2)
@@ -216,7 +216,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::range("test_date_field")
                 .gt(Utc.ymd(2014, 11, 28).and_hms(12, 0, 1))
                 .gte(Utc.ymd(2014, 11, 28).and_hms(12, 0, 2))

--- a/src/search/queries/term_level/regexp_query.rs
+++ b/src/search/queries/term_level/regexp_query.rs
@@ -150,7 +150,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::regexp("test", "regexp"),
             json!({
                 "regexp": {
@@ -161,7 +161,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::regexp("test", "regexp")
                 .flags([RegexpFlag::Complement, RegexpFlag::Interval])
                 .case_insensitive(false)

--- a/src/search/queries/term_level/term_query.rs
+++ b/src/search/queries/term_level/term_query.rs
@@ -88,7 +88,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::term("test", 123),
             json!({
                 "term": {
@@ -99,7 +99,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::term("test", 123).boost(2).name("test"),
             json!({
                 "term": {
@@ -112,7 +112,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::bool().filter(Query::term("test", None::<String>)),
             json!({ "bool": {} }),
         )

--- a/src/search/queries/term_level/terms_lookup_query.rs
+++ b/src/search/queries/term_level/terms_lookup_query.rs
@@ -115,7 +115,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::terms_lookup("test", "index_value", "id_value", "path_value"),
             json!({
                 "terms": {
@@ -128,7 +128,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::terms_lookup("test", "index_value", "id_value", "path_value")
                 .routing("routing_value")
                 .boost(2)

--- a/src/search/queries/term_level/terms_query.rs
+++ b/src/search/queries/term_level/terms_query.rs
@@ -82,12 +82,12 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::terms("test", vec![123, 12, 13]),
             json!({"terms": { "test": [12, 13, 123] } }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::terms("test", vec![123]).boost(2).name("test"),
             json!({
                 "terms": {

--- a/src/search/queries/term_level/terms_set_query.rs
+++ b/src/search/queries/term_level/terms_set_query.rs
@@ -101,7 +101,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::terms_set("test", [123], "required_matches"),
             json!({
                 "terms_set": {
@@ -113,7 +113,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::terms_set(
                 "programming_languages",
                 ["c++", "java", "php"],

--- a/src/search/queries/term_level/wildcard_query.rs
+++ b/src/search/queries/term_level/wildcard_query.rs
@@ -104,7 +104,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        assert_serialize(
+        assert_serialize_query(
             Query::wildcard("test", "value*"),
             json!({
                 "wildcard": {
@@ -115,7 +115,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::wildcard("test", "value*")
                 .rewrite(Rewrite::ConstantScore)
                 .case_insensitive(true)
@@ -134,7 +134,7 @@ mod tests {
             }),
         );
 
-        assert_serialize(
+        assert_serialize_query(
             Query::bool().filter(Query::wildcard("test", None::<String>)),
             json!({ "bool": {} }),
         )

--- a/src/util/assert_serialize.rs
+++ b/src/util/assert_serialize.rs
@@ -9,3 +9,15 @@ where
 
     assert_eq!(result, expectation)
 }
+
+/// Tests if a query is serialized to correct JSON [`Value`]
+#[cfg(test)]
+pub(crate) fn assert_serialize_query<S>(subject: S, expectation: serde_json::Value)
+where
+    S: Into<crate::Query>,
+{
+    let subject = crate::Search::new().query(subject);
+    let expectation = json!({ "query": expectation });
+
+    assert_serialize(subject, expectation)
+}


### PR DESCRIPTION
In addition to checking if the query is serialized correctly, it will also check if this can be converted into a Query. This immediately has found 6 queries that I forgot to add to the queries enum.

