### PR TITLE
Use explicit generic types 

### DIFF
--- a/src/search/aggregations/bucket/diversified_sampler_aggregation.rs
+++ b/src/search/aggregations/bucket/diversified_sampler_aggregation.rs
@@ -1,6 +1,5 @@
 use crate::search::*;
 use crate::util::*;
-use std::convert::TryInto;
 
 /// Like the sampler aggregation this is a filtering aggregation used to limit any sub aggregations' processing
 /// to a sample of the top-scoring documents. The diversified_sampler aggregation adds the ability to limit
@@ -45,7 +44,10 @@ struct DiversifiedSamplerAggregationInner {
 
 impl Aggregation {
     /// Creates an instance of [`DiversifiedSamplerAggregation`]
-    pub fn diversified_sampler(field: impl Into<String>) -> DiversifiedSamplerAggregation {
+    pub fn diversified_sampler<T>(field: T) -> DiversifiedSamplerAggregation
+    where
+        T: Into<String>,
+    {
         DiversifiedSamplerAggregation {
             diversified_sampler: DiversifiedSamplerAggregationInner {
                 field: field.into(),
@@ -61,19 +63,15 @@ impl Aggregation {
 impl DiversifiedSamplerAggregation {
     /// The `shard_size` parameter limits how many top-scoring documents are
     /// collected in the sample processed on each shard. The default value is 100.
-    pub fn shard_size(mut self, shard_size: impl TryInto<u64>) -> Self {
-        if let Ok(shard_size) = shard_size.try_into() {
-            self.diversified_sampler.shard_size = Some(shard_size);
-        }
+    pub fn shard_size(mut self, shard_size: u64) -> Self {
+        self.diversified_sampler.shard_size = Some(shard_size);
         self
     }
 
     /// The `max_docs_per_value` is an optional parameter and limits how many documents
     /// are permitted per choice of de-duplicating value. The default setting is "1".
-    pub fn max_docs_per_value(mut self, max_docs_per_value: impl TryInto<u64>) -> Self {
-        if let Ok(max_docs_per_value) = max_docs_per_value.try_into() {
-            self.diversified_sampler.max_docs_per_value = Some(max_docs_per_value);
-        }
+    pub fn max_docs_per_value(mut self, max_docs_per_value: u64) -> Self {
+        self.diversified_sampler.max_docs_per_value = Some(max_docs_per_value);
         self
     }
 
@@ -85,7 +83,6 @@ impl DiversifiedSamplerAggregation {
     /// - hold hashes of the field values - with potential for hash collisions (`bytes_hash`)
     pub fn execution_hint(mut self, execution_hint: ExecutionHint) -> Self {
         self.diversified_sampler.execution_hint = Some(execution_hint);
-
         self
     }
 

--- a/src/search/aggregations/bucket/sampler_aggregation.rs
+++ b/src/search/aggregations/bucket/sampler_aggregation.rs
@@ -32,7 +32,7 @@ impl Aggregation {
 impl SamplerAggregation {
     /// The shard_size parameter limits how many top-scoring documents are
     /// collected in the sample processed on each shard. The default value is 100.
-    pub fn shard_size(mut self, shard_size: impl TryInto<u64>) -> Self {
+    pub fn shard_size(mut self, shard_size: u64) -> Self {
         if let Ok(shard_size) = shard_size.try_into() {
             self.sampler.shard_size = Some(shard_size);
         }

--- a/src/search/aggregations/bucket/terms_aggregation.rs
+++ b/src/search/aggregations/bucket/terms_aggregation.rs
@@ -42,7 +42,10 @@ impl TermsAggregationOrder {
     ///
     /// - `field` - Field to sort by
     /// - `order` - Ordering direction
-    pub fn new(field: impl Into<SortField>, order: SortOrder) -> Self {
+    pub fn new<T>(field: T, order: SortOrder) -> Self
+    where
+        T: Into<SortField>,
+    {
         Self(KeyValuePair::new(field.into(), order))
     }
 }
@@ -60,7 +63,10 @@ impl Aggregation {
     /// Creates an instance of [`TermsAggregation`]
     ///
     /// - `field` - field to group by
-    pub fn terms(field: impl Into<String>) -> TermsAggregation {
+    pub fn terms<T>(field: T) -> TermsAggregation
+    where
+        T: Into<String>,
+    {
         TermsAggregation {
             terms: TermsAggregationInner {
                 field: field.into(),
@@ -83,7 +89,7 @@ impl TermsAggregation {
     ///
     /// This means that if the number of unique terms is greater than `size`, the returned list is slightly off and not accurate
     /// (it could be that the term counts are slightly off and it could even be that a term that should have been in the top `size` buckets was not returned).
-    pub fn size(mut self, size: impl TryInto<u64>) -> Self {
+    pub fn size(mut self, size: u64) -> Self {
         if let Ok(size) = size.try_into() {
             self.terms.size = Some(size);
         }
@@ -111,7 +117,10 @@ impl TermsAggregation {
     /// [min](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html) or
     /// [max](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html)
     /// aggregation: counts will not be accurate but at least the top buckets will be correctly picked.
-    pub fn order(mut self, order: impl Into<TermsAggregationOrder>) -> Self {
+    pub fn order<T>(mut self, order: T) -> Self
+    where
+        T: Into<TermsAggregationOrder>,
+    {
         self.terms.order.push(order.into());
         self
     }
@@ -119,14 +128,17 @@ impl TermsAggregation {
     /// Only returns terms that match more than a configured number of hits using the `min_doc_count`
     ///
     /// Default value is `1`
-    pub fn min_doc_count(mut self, min_doc_count: impl Into<u16>) -> Self {
+    pub fn min_doc_count(mut self, min_doc_count: u16) -> Self {
         self.terms.min_doc_count = Some(min_doc_count.into());
         self
     }
 
     /// The missing parameter defines how documents that are missing a value should be treated.
     /// By default they will be ignored but it is also possible to treat them as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Term>) -> Self {
+    pub fn missing<T>(mut self, missing: T) -> Self
+    where
+        T: Into<Term>,
+    {
         self.terms.missing = Some(missing.into());
         self
     }
@@ -147,7 +159,7 @@ mod tests {
 
         assert_serialize_aggregation(
             Aggregation::terms("test_field")
-                .size(5u16)
+                .size(5)
                 .min_doc_count(2u16)
                 .show_term_doc_count_error(false)
                 .missing("N/A")
@@ -168,12 +180,12 @@ mod tests {
 
         assert_serialize_aggregation(
             Aggregation::terms("test_field")
-                .size(0u16)
+                .size(0)
                 .order(("test_order", SortOrder::Asc))
                 .missing(123)
                 .aggregate(
                     "test_sub_agg",
-                    Aggregation::terms("test_field2").size(3u16).missing(false),
+                    Aggregation::terms("test_field2").size(3).missing(false),
                 ),
             json!({
                 "terms": {

--- a/src/search/aggregations/metrics/avg_aggregation.rs
+++ b/src/search/aggregations/metrics/avg_aggregation.rs
@@ -23,7 +23,10 @@ impl Aggregation {
     /// Creates an instance of [`AvgAggregation`]
     ///
     /// - `field` - field to aggregate
-    pub fn avg(field: impl Into<String>) -> AvgAggregation {
+    pub fn avg<T>(field: T) -> AvgAggregation
+    where
+        T: Into<String>,
+    {
         AvgAggregation {
             avg: AvgAggregationInner {
                 field: field.into(),
@@ -36,7 +39,10 @@ impl Aggregation {
 impl AvgAggregation {
     /// The missing parameter defines how documents that are missing a value should be treated. By
     /// default they will be ignored but it is also possible to treat them as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Number>) -> Self {
+    pub fn missing<T>(mut self, missing: T) -> Self
+    where
+        T: Into<Number>,
+    {
         self.avg.missing = Some(missing.into());
         self
     }

--- a/src/search/aggregations/metrics/boxplot_aggregation.rs
+++ b/src/search/aggregations/metrics/boxplot_aggregation.rs
@@ -33,7 +33,10 @@ impl Aggregation {
     /// Creates an instance of [`BoxplotAggregation`]
     ///
     /// - `field` - field to aggregate
-    pub fn boxplot(field: impl Into<String>) -> BoxplotAggregation {
+    pub fn boxplot<T>(field: T) -> BoxplotAggregation
+    where
+        T: Into<String>,
+    {
         BoxplotAggregation {
             boxplot: BoxplotAggregationInner {
                 field: field.into(),
@@ -59,14 +62,20 @@ impl BoxplotAggregation {
     /// A "node" uses roughly 32 bytes of memory, so under worst-case scenarios (large amount of
     /// data which arrives sorted and in-order) the default settings will produce a TDigest roughly
     /// 64KB in size. In practice data tends to be more random and the TDigest will use less memory.
-    pub fn compression(mut self, compression: impl Into<Number>) -> Self {
+    pub fn compression<T>(mut self, compression: T) -> Self
+    where
+        T: Into<Number>,
+    {
         self.boxplot.compression = Some(compression.into());
         self
     }
 
     /// The `missing` parameter defines how documents that are missing a value should be treated.
     /// By default they will be ignored but it is also possible to treat them as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Number>) -> Self {
+    pub fn missing<T>(mut self, missing: T) -> Self
+    where
+        T: Into<Number>,
+    {
         self.boxplot.missing = Some(missing.into());
         self
     }

--- a/src/search/aggregations/metrics/cardinality_aggregation.rs
+++ b/src/search/aggregations/metrics/cardinality_aggregation.rs
@@ -24,7 +24,10 @@ impl Aggregation {
     /// Creates an instance of [`CardinalityAggregation`]
     ///
     /// - `field` - field to aggregate
-    pub fn cardinality(field: impl Into<String>) -> CardinalityAggregation {
+    pub fn cardinality<T>(field: T) -> CardinalityAggregation
+    where
+        T: Into<String>,
+    {
         CardinalityAggregation {
             cardinality: CardinalityAggregationInner {
                 field: field.into(),
@@ -40,14 +43,17 @@ impl CardinalityAggregation {
     /// which counts are expected to be close to accurate. Above this value, counts might become a bit more fuzzy.
     /// The maximum supported value is 40000, thresholds above this number will have the same effect as a threshold
     /// of 40000. The default value is 3000
-    pub fn precision_threshold(mut self, precision_threshold: impl Into<u16>) -> Self {
+    pub fn precision_threshold(mut self, precision_threshold: u16) -> Self {
         self.cardinality.precision_threshold = Some(precision_threshold.into());
         self
     }
 
     /// The `missing` parameter defines how documents that are missing a value should be treated. By default they will
     /// be ignored but it is also possible to treat them as if they had a value.
-    pub fn missing(mut self, missing: impl Into<String>) -> Self {
+    pub fn missing<T>(mut self, missing: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.cardinality.missing = Some(missing.into());
         self
     }

--- a/src/search/aggregations/metrics/max_aggregation.rs
+++ b/src/search/aggregations/metrics/max_aggregation.rs
@@ -26,7 +26,10 @@ impl Aggregation {
     /// Creates an instance of [`MaxAggregation`]
     ///
     /// - `field` - field to aggregate
-    pub fn max(field: impl Into<String>) -> MaxAggregation {
+    pub fn max<T>(field: T) -> MaxAggregation
+    where
+        T: Into<String>,
+    {
         MaxAggregation {
             max: MaxAggregationInner {
                 field: field.into(),
@@ -39,7 +42,10 @@ impl Aggregation {
 impl MaxAggregation {
     /// The `missing` parameter defines how documents that are missing a value should be treated. By
     /// default they will be ignored but it is also possible to treat them as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Number>) -> Self {
+    pub fn missing<T>(mut self, missing: T) -> Self
+    where
+        T: Into<Number>,
+    {
         self.max.missing = Some(missing.into());
         self
     }

--- a/src/search/aggregations/metrics/min_aggregation.rs
+++ b/src/search/aggregations/metrics/min_aggregation.rs
@@ -26,7 +26,10 @@ impl Aggregation {
     /// Creates an instance of [`MinAggregation`]
     ///
     /// - `field` - field to aggregate
-    pub fn min(field: impl Into<String>) -> MinAggregation {
+    pub fn min<T>(field: T) -> MinAggregation
+    where
+        T: Into<String>,
+    {
         MinAggregation {
             min: MinAggregationInner {
                 field: field.into(),
@@ -39,7 +42,10 @@ impl Aggregation {
 impl MinAggregation {
     /// The `missing` parameter defines how documents that are missing a value should be treated. By
     /// default they will be ignored but it is also possible to treat them as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Number>) -> Self {
+    pub fn missing<T>(mut self, missing: T) -> Self
+    where
+        T: Into<Number>,
+    {
         self.min.missing = Some(missing.into());
         self
     }

--- a/src/search/aggregations/metrics/rate_aggregation.rs
+++ b/src/search/aggregations/metrics/rate_aggregation.rs
@@ -37,7 +37,10 @@ impl Aggregation {
 
 impl RateAggregation {
     /// Calculate sum or number of values of the `field`
-    pub fn field(mut self, field: impl Into<String>) -> Self {
+    pub fn field<T>(mut self, field: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.rate.field = Some(field.into());
         self
     }
@@ -53,8 +56,8 @@ impl RateAggregation {
     /// if the date histogram is month based, only rate intervals of month, quarter or year are
     /// supported. If the date histogram is `day` based, only `second`, ` minute`, `hour`, `day,
     /// and `week` rate intervals are supported.
-    pub fn unit(mut self, unit: impl Into<CalendarInterval>) -> Self {
-        self.rate.unit = Some(unit.into());
+    pub fn unit(mut self, unit: CalendarInterval) -> Self {
+        self.rate.unit = Some(unit);
         self
     }
 
@@ -62,8 +65,8 @@ impl RateAggregation {
     ///
     /// By adding the `mode` parameter with the value `value_count`, we can change the calculation from
     /// `sum` to the number of values of the field.
-    pub fn mode(mut self, mode: impl Into<RateMode>) -> Self {
-        self.rate.mode = Some(mode.into());
+    pub fn mode(mut self, mode: RateMode) -> Self {
+        self.rate.mode = Some(mode);
         self
     }
 }

--- a/src/search/aggregations/metrics/sum_aggregation.rs
+++ b/src/search/aggregations/metrics/sum_aggregation.rs
@@ -22,7 +22,10 @@ impl Aggregation {
     /// Creates an instance of [`SumAggregation`]
     ///
     /// - `field` - field to aggregate
-    pub fn sum(field: impl Into<String>) -> SumAggregation {
+    pub fn sum<T>(field: T) -> SumAggregation
+    where
+        T: Into<String>,
+    {
         SumAggregation {
             sum: SumAggregationInner {
                 field: field.into(),
@@ -36,7 +39,10 @@ impl SumAggregation {
     /// The `missing` parameter defines how documents that are missing a value should be treated. By
     /// default documents missing the value will be ignored but it is also possible to treat them
     /// as if they had a value.
-    pub fn missing(mut self, missing: impl Into<Number>) -> Self {
+    pub fn missing<T>(mut self, missing: T) -> Self
+    where
+        T: Into<Number>,
+    {
         self.sum.missing = Some(missing.into());
         self
     }

--- a/src/search/aggregations/metrics/top_hits_aggregation.rs
+++ b/src/search/aggregations/metrics/top_hits_aggregation.rs
@@ -52,13 +52,16 @@ impl Aggregation {
 
 impl TopHitsAggregation {
     /// Indicates which source fields are returned for matching documents
-    pub fn source(mut self, source: impl Into<SourceFilter>) -> Self {
+    pub fn source<T>(mut self, source: T) -> Self
+    where
+        T: Into<SourceFilter>,
+    {
         self.top_hits._source = Some(source.into());
         self
     }
 
     /// The offset from the first result you want to fetch.
-    pub fn from(mut self, from: impl TryInto<u64>) -> Self {
+    pub fn from(mut self, from: u64) -> Self {
         if let Ok(from) = from.try_into() {
             self.top_hits.from = Some(from);
         }
@@ -68,7 +71,7 @@ impl TopHitsAggregation {
     /// The maximum number of top matching hits to return per bucket.
     ///
     /// By default the top three matching hits are returned.
-    pub fn size(mut self, size: impl TryInto<u64>) -> Self {
+    pub fn size(mut self, size: u64) -> Self {
         if let Ok(size) = size.try_into() {
             self.top_hits.size = Some(size);
         }
@@ -76,7 +79,10 @@ impl TopHitsAggregation {
     }
 
     /// A collection of sorting fields
-    pub fn sort(mut self, sort: impl Into<Vec<Sort>>) -> Self {
+    pub fn sort<T>(mut self, sort: T) -> Self
+    where
+        T: Into<Vec<Sort>>,
+    {
         self.top_hits.sort.extend(sort.into());
         self
     }
@@ -93,8 +99,8 @@ mod tests {
         assert_serialize_aggregation(
             Aggregation::top_hits()
                 .source(false)
-                .from(2u8)
-                .size(10u8)
+                .from(2)
+                .size(10)
                 .sort(Sort::new("sort_field").order(SortOrder::Desc)),
             json!({
                 "top_hits": {

--- a/src/search/highlight/highlighter.rs
+++ b/src/search/highlight/highlighter.rs
@@ -381,7 +381,10 @@ impl From<UnifiedHighlighter> for Highlighter {
 macro_rules! add_highlighter_methods {
     () => {
         /// A string that contains each boundary character. Defaults to `.,!? \t\n`.
-        pub fn boundary_chars(mut self, boundary_chars: impl Into<String>) -> Self {
+        pub fn boundary_chars<T>(mut self, boundary_chars: T) -> Self
+        where
+            T: Into<String>,
+        {
             self.boundary_chars = Some(boundary_chars.into());
             self
         }
@@ -418,7 +421,10 @@ macro_rules! add_highlighter_methods {
         /// > Elasticsearch does not validate that `highlight_query` contains the search query in any
         /// way so it is possible to define it so legitimate query results are not highlighted.
         /// Generally, you should include the search query as part of the `highlight_query`.
-        pub fn highlight_query(mut self, highlight_query: impl Into<Query>) -> Self {
+        pub fn highlight_query<T>(mut self, highlight_query: T) -> Self
+        where
+            T: Into<Query>,
+        {
             self.highlight_query = Some(highlight_query.into());
             self
         }
@@ -460,7 +466,10 @@ macro_rules! add_highlighter_methods {
         }
 
         /// Set to `styled` to use the built-in tag schema or use custom tags
-        pub fn tags(mut self, tags: impl Into<Tags>) -> Self {
+        pub fn tags<T>(mut self, tags: T) -> Self
+        where
+            T: Into<Tags>,
+        {
             self.tags = Some(tags.into());
             self
         }
@@ -527,7 +536,10 @@ impl FastVectorHighlighter {
     /// multi-fields that analyze the same string in different ways. All `matched_fields` must have
     /// `term_vector` set to `with_positions_offsets`, but only the field to which the matches are
     /// combined is loaded so only that field benefits from having store set to yes.
-    pub fn matched_fields(mut self, matched_fields: impl Into<MatchedFields>) -> Self {
+    pub fn matched_fields<T>(mut self, matched_fields: T) -> Self
+    where
+        T: Into<MatchedFields>,
+    {
         self.matched_fields = Some(matched_fields.into());
         self
     }

--- a/src/search/params/geo_point.rs
+++ b/src/search/params/geo_point.rs
@@ -48,7 +48,10 @@ impl GeoPoint {
     }
 
     /// Creates an instance of [GeoPoint](GeoPoint)
-    pub fn geohash(geohash: impl Into<String>) -> Self {
+    pub fn geohash<T>(geohash: T) -> Self
+    where
+        T: Into<String>,
+    {
         Self::Geohash(geohash.into())
     }
 }

--- a/src/search/queries/compound/constant_score_query.rs
+++ b/src/search/queries/compound/constant_score_query.rs
@@ -41,7 +41,10 @@ impl Query {
     /// Filter queries do not calculate
     /// [relevance scores](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores).
     /// To speed up performance, Elasticsearch automatically caches frequently used filter queries.
-    pub fn constant_score(filter: impl Into<Query>) -> ConstantScoreQuery {
+    pub fn constant_score<T>(filter: T) -> ConstantScoreQuery
+    where
+        T: Into<Query>,
+    {
         ConstantScoreQuery {
             inner: Inner {
                 filter: Box::new(filter.into()),

--- a/src/search/queries/compound/function_score_query.rs
+++ b/src/search/queries/compound/function_score_query.rs
@@ -59,7 +59,10 @@ struct Inner {
 
 impl Query {
     /// Creates an instance of [`FunctionScoreQuery`]
-    pub fn function_score(query: impl Into<Query>) -> FunctionScoreQuery {
+    pub fn function_score<T>(query: T) -> FunctionScoreQuery
+    where
+        T: Into<Query>,
+    {
         FunctionScoreQuery {
             inner: Inner {
                 query: Box::new(query.into()),
@@ -77,7 +80,10 @@ impl Query {
 
 impl FunctionScoreQuery {
     /// Push function to the list
-    pub fn function(mut self, function: impl Into<Option<Function>>) -> Self {
+    pub fn function<T>(mut self, function: T) -> Self
+    where
+        T: Into<Option<Function>>,
+    {
         let function = function.into();
 
         if let Some(function) = function {
@@ -88,7 +94,10 @@ impl FunctionScoreQuery {
     }
 
     /// Maximum score value after applying all the functions
-    pub fn max_boost(mut self, max_boost: impl std::convert::TryInto<Boost>) -> Self {
+    pub fn max_boost<T>(mut self, max_boost: T) -> Self
+    where
+        T: std::convert::TryInto<Boost>,
+    {
         if let Ok(max_boost) = max_boost.try_into() {
             self.inner.max_boost = Some(max_boost);
         }
@@ -99,7 +108,10 @@ impl FunctionScoreQuery {
 
     /// that do not meet a certain score threshold the `min_score` parameter can be set to the
     /// desired score threshold.
-    pub fn min_score(mut self, min_score: impl Into<f32>) -> Self {
+    pub fn min_score<T>(mut self, min_score: T) -> Self
+    where
+        T: Into<f32>,
+    {
         self.inner.min_score = Some(min_score.into());
         self
     }

--- a/src/search/queries/full_text/combined_fields_query.rs
+++ b/src/search/queries/full_text/combined_fields_query.rs
@@ -104,10 +104,10 @@ impl CombinedFieldsQuery {
     /// See the
     /// [`minimum_should_match` parameter](crate::MinimumShouldMatch)
     /// for valid values and more information.
-    pub fn minimum_should_match(
-        mut self,
-        minimum_should_match: impl Into<MinimumShouldMatch>,
-    ) -> Self {
+    pub fn minimum_should_match<T>(mut self, minimum_should_match: T) -> Self
+    where
+        T: Into<MinimumShouldMatch>,
+    {
         self.inner.minimum_should_match = Some(minimum_should_match.into());
         self
     }

--- a/src/search/queries/full_text/match_bool_prefix_query.rs
+++ b/src/search/queries/full_text/match_bool_prefix_query.rs
@@ -49,10 +49,11 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `query` - Text, number, boolean value or date you wish to find in the provided `<field>`
-    pub fn match_bool_prefix(
-        field: impl Into<String>,
-        query: impl Into<Text>,
-    ) -> MatchBoolPrefixQuery {
+    pub fn match_bool_prefix<T, U>(field: T, query: U) -> MatchBoolPrefixQuery
+    where
+        T: Into<String>,
+        U: Into<Text>,
+    {
         MatchBoolPrefixQuery {
             field: field.into(),
             inner: Inner {
@@ -72,7 +73,10 @@ impl MatchBoolPrefixQuery {
     /// used to convert the text in the `query` value into tokens. Defaults to the
     /// [index-time analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/current/specify-analyzer.html#specify-index-time-analyzer)
     /// mapped for the `<field>`. If no analyzer is mapped, the index’s default analyzer is used.
-    pub fn analyzer(mut self, analyzer: impl Into<String>) -> Self {
+    pub fn analyzer<T>(mut self, analyzer: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.analyzer = Some(analyzer.into());
         self
     }
@@ -81,10 +85,10 @@ impl MatchBoolPrefixQuery {
     /// See the
     /// [`minimum_should_match` parameter](MinimumShouldMatch)
     /// for valid values and more information.
-    pub fn minimum_should_match(
-        mut self,
-        minimum_should_match: impl Into<MinimumShouldMatch>,
-    ) -> Self {
+    pub fn minimum_should_match<T>(mut self, minimum_should_match: T) -> Self
+    where
+        T: Into<MinimumShouldMatch>,
+    {
         self.inner.minimum_should_match = Some(minimum_should_match.into());
         self
     }

--- a/src/search/queries/full_text/match_phrase_prefix_query.rs
+++ b/src/search/queries/full_text/match_phrase_prefix_query.rs
@@ -54,10 +54,11 @@ impl Query {
     /// query analyzes any provided text into tokens before performing a search. The last term of
     /// this text is treated as a [prefix](crate::PrefixQuery), matching any words that begin with
     /// that term.
-    pub fn match_phrase_prefix(
-        field: impl Into<String>,
-        query: impl Into<Text>,
-    ) -> MatchPhrasePrefixQuery {
+    pub fn match_phrase_prefix<T, U>(field: T, query: U) -> MatchPhrasePrefixQuery
+    where
+        T: Into<String>,
+        U: Into<Text>,
+    {
         MatchPhrasePrefixQuery {
             field: field.into(),
             inner: Inner {
@@ -78,7 +79,10 @@ impl MatchPhrasePrefixQuery {
     /// used to convert the text in the `query` value into tokens. Defaults to the
     /// [index-time analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/current/specify-analyzer.html#specify-index-time-analyzer)
     /// mapped for the `<field>`. If no analyzer is mapped, the index’s default analyzer is used.
-    pub fn analyzer(mut self, analyzer: impl Into<String>) -> Self {
+    pub fn analyzer<T>(mut self, analyzer: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.analyzer = Some(analyzer.into());
         self
     }

--- a/src/search/queries/full_text/match_phrase_query.rs
+++ b/src/search/queries/full_text/match_phrase_query.rs
@@ -51,7 +51,11 @@ impl Query {
     /// `match_phrase` query can search
     /// [`text`](https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html)
     /// fields for analyzed tokens rather than an exact term.
-    pub fn match_phrase(field: impl Into<String>, query: impl Into<Text>) -> MatchPhraseQuery {
+    pub fn match_phrase<T, U>(field: T, query: U) -> MatchPhraseQuery
+    where
+        T: Into<String>,
+        U: Into<Text>,
+    {
         MatchPhraseQuery {
             field: field.into(),
             inner: Inner {
@@ -70,7 +74,10 @@ impl MatchPhraseQuery {
     /// used to convert the text in the `query` value into tokens. Defaults to the
     /// [index-time analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/current/specify-analyzer.html#specify-index-time-analyzer)
     /// mapped for the `<field>`. If no analyzer is mapped, the index’s default analyzer is used.
-    pub fn analyzer(mut self, analyzer: impl Into<String>) -> Self {
+    pub fn analyzer<T>(mut self, analyzer: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.analyzer = Some(analyzer.into());
         self
     }

--- a/src/search/queries/full_text/match_query.rs
+++ b/src/search/queries/full_text/match_query.rs
@@ -81,7 +81,11 @@ impl Query {
     /// query can search
     /// [`text`](https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html)
     /// fields for analyzed tokens rather than an exact term.
-    pub fn r#match(field: impl Into<String>, query: impl Into<Text>) -> MatchQuery {
+    pub fn r#match<T, U>(field: T, query: U) -> MatchQuery
+    where
+        T: Into<String>,
+        U: Into<Text>,
+    {
         MatchQuery {
             field: field.into(),
             inner: Inner {
@@ -109,7 +113,10 @@ impl MatchQuery {
     /// used to convert the text in the `query` value into tokens. Defaults to the
     /// [index-time analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/current/specify-analyzer.html#specify-index-time-analyzer)
     /// mapped for the `<field>`. If no analyzer is mapped, the index’s default analyzer is used.
-    pub fn analyzer(mut self, analyzer: impl Into<String>) -> Self {
+    pub fn analyzer<T>(mut self, analyzer: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.analyzer = Some(analyzer.into());
         self
     }
@@ -133,7 +140,10 @@ impl MatchQuery {
     /// for valid values and more information. See
     /// [Fuzziness in the match query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#query-dsl-match-query-fuzziness)
     /// for an example.
-    pub fn fuzziness(mut self, fuzziness: impl Into<Fuzziness>) -> Self {
+    pub fn fuzziness<T>(mut self, fuzziness: T) -> Self
+    where
+        T: Into<Fuzziness>,
+    {
         self.inner.fuzziness = Some(fuzziness.into());
         self
     }
@@ -190,10 +200,10 @@ impl MatchQuery {
     /// See the
     /// [`minimum_should_match` parameter](MinimumShouldMatch)
     /// for valid values and more information.
-    pub fn minimum_should_match(
-        mut self,
-        minimum_should_match: impl Into<MinimumShouldMatch>,
-    ) -> Self {
+    pub fn minimum_should_match<T>(mut self, minimum_should_match: T) -> Self
+    where
+        T: Into<MinimumShouldMatch>,
+    {
         self.inner.minimum_should_match = Some(minimum_should_match.into());
         self
     }

--- a/src/search/queries/full_text/multi_match_query.rs
+++ b/src/search/queries/full_text/multi_match_query.rs
@@ -134,7 +134,10 @@ impl MultiMatchQuery {
     /// used to convert the text in the `query` value into tokens. Defaults to the
     /// [index-time analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/current/specify-analyzer.html#specify-index-time-analyzer)
     /// mapped for the `<field>`. If no analyzer is mapped, the index’s default analyzer is used.
-    pub fn analyzer(mut self, analyzer: impl Into<String>) -> Self {
+    pub fn analyzer<T>(mut self, analyzer: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.analyzer = Some(analyzer.into());
         self
     }
@@ -158,7 +161,10 @@ impl MultiMatchQuery {
     /// for valid values and more information. See
     /// [Fuzziness in the match query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#query-dsl-match-query-fuzziness)
     /// for an example.
-    pub fn fuzziness(mut self, fuzziness: impl Into<Fuzziness>) -> Self {
+    pub fn fuzziness<T>(mut self, fuzziness: T) -> Self
+    where
+        T: Into<Fuzziness>,
+    {
         self.inner.fuzziness = Some(fuzziness.into());
         self
     }
@@ -215,10 +221,10 @@ impl MultiMatchQuery {
     /// See the
     /// [`minimum_should_match` parameter](crate::MinimumShouldMatch)
     /// for valid values and more information.
-    pub fn minimum_should_match(
-        mut self,
-        minimum_should_match: impl Into<MinimumShouldMatch>,
-    ) -> Self {
+    pub fn minimum_should_match<T>(mut self, minimum_should_match: T) -> Self
+    where
+        T: Into<MinimumShouldMatch>,
+    {
         self.inner.minimum_should_match = Some(minimum_should_match.into());
         self
     }

--- a/src/search/queries/full_text/query_string_query.rs
+++ b/src/search/queries/full_text/query_string_query.rs
@@ -186,7 +186,10 @@ impl QueryStringQuery {
     /// [index-time analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/current/specify-analyzer.html#specify-index-time-analyzer)
     /// mapped for the `default_field`. If no analyzer is mapped, the index’s
     /// default analyzer is used.
-    pub fn analyzer(mut self, analyzer: impl Into<String>) -> Self {
+    pub fn analyzer<T>(mut self, analyzer: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.analyzer = Some(analyzer.into());
         self
     }
@@ -301,10 +304,10 @@ impl QueryStringQuery {
     /// See the
     /// [`minimum_should_match` parameter](crate::MinimumShouldMatch)
     /// for valid values and more information.
-    pub fn minimum_should_match(
-        mut self,
-        minimum_should_match: impl Into<MinimumShouldMatch>,
-    ) -> Self {
+    pub fn minimum_should_match<T>(mut self, minimum_should_match: T) -> Self
+    where
+        T: Into<MinimumShouldMatch>,
+    {
         self.inner.minimum_should_match = Some(minimum_should_match.into());
         self
     }

--- a/src/search/queries/full_text/simple_query_string_query.rs
+++ b/src/search/queries/full_text/simple_query_string_query.rs
@@ -148,7 +148,10 @@ impl SimpleQueryStringQuery {
     /// [index-time analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/current/specify-analyzer.html#specify-index-time-analyzer)
     /// mapped for the `default_field`. If no analyzer is mapped, the index’s
     /// default analyzer is used.
-    pub fn analyzer(mut self, analyzer: impl Into<String>) -> Self {
+    pub fn analyzer<T>(mut self, analyzer: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.analyzer = Some(analyzer.into());
         self
     }
@@ -220,10 +223,10 @@ impl SimpleQueryStringQuery {
     /// See the
     /// [`minimum_should_match` parameter](crate::MinimumShouldMatch)
     /// for valid values and more information.
-    pub fn minimum_should_match(
-        mut self,
-        minimum_should_match: impl Into<MinimumShouldMatch>,
-    ) -> Self {
+    pub fn minimum_should_match<T>(mut self, minimum_should_match: T) -> Self
+    where
+        T: Into<MinimumShouldMatch>,
+    {
         self.inner.minimum_should_match = Some(minimum_should_match.into());
         self
     }

--- a/src/search/queries/geo/geo_bounding_box_query.rs
+++ b/src/search/queries/geo/geo_bounding_box_query.rs
@@ -30,10 +30,11 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `value` - A series of vertex coordinates of a geo bounding box
-    pub fn geo_bounding_box(
-        field: impl Into<String>,
-        value: impl Into<GeoBoundingBox>,
-    ) -> GeoBoundingBoxQuery {
+    pub fn geo_bounding_box<T, U>(field: T, value: U) -> GeoBoundingBoxQuery
+    where
+        T: Into<String>,
+        U: Into<GeoBoundingBox>,
+    {
         GeoBoundingBoxQuery {
             inner: Inner {
                 pair: KeyValuePair::new(field.into(), value.into()),
@@ -48,8 +49,8 @@ impl Query {
 impl GeoBoundingBoxQuery {
     /// Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude, set to
     /// `COERCE` to also try to infer correct latitude or longitude. (default is `STRICT`).
-    pub fn validation_method(mut self, validation_method: impl Into<ValidationMethod>) -> Self {
-        self.inner.validation_method = Some(validation_method.into());
+    pub fn validation_method(mut self, validation_method: ValidationMethod) -> Self {
+        self.inner.validation_method = Some(validation_method);
         self
     }
 

--- a/src/search/queries/geo/geo_distance_query.rs
+++ b/src/search/queries/geo/geo_distance_query.rs
@@ -39,11 +39,12 @@ impl Query {
     /// - `field` - Field you wish to search
     /// - `origin` - GeoPoint to measure distance to
     /// - `distance` - Distance threshold
-    pub fn geo_distance(
-        field: impl Into<String>,
-        origin: impl Into<GeoPoint>,
-        distance: impl Into<Distance>,
-    ) -> GeoDistanceQuery {
+    pub fn geo_distance<T, U, V>(field: T, origin: U, distance: V) -> GeoDistanceQuery
+    where
+        T: Into<String>,
+        U: Into<GeoPoint>,
+        V: Into<Distance>,
+    {
         GeoDistanceQuery {
             inner: Inner {
                 pair: KeyValuePair::new(field.into(), origin.into()),
@@ -60,15 +61,15 @@ impl Query {
 impl GeoDistanceQuery {
     /// Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude, set to
     /// `COERCE` to also try to infer correct latitude or longitude. (default is `STRICT`).
-    pub fn validation_method(mut self, validation_method: impl Into<ValidationMethod>) -> Self {
-        self.inner.validation_method = Some(validation_method.into());
+    pub fn validation_method(mut self, validation_method: ValidationMethod) -> Self {
+        self.inner.validation_method = Some(validation_method);
         self
     }
 
     /// How to compute the distance. Can either be `Arc` (default),
     /// or `Plane` (faster, but inaccurate on long distances and close to the poles).
-    pub fn distance_type(mut self, distance_type: impl Into<DistanceType>) -> Self {
-        self.inner.distance_type = Some(distance_type.into());
+    pub fn distance_type(mut self, distance_type: DistanceType) -> Self {
+        self.inner.distance_type = Some(distance_type);
         self
     }
 

--- a/src/search/queries/joining/has_child_query.rs
+++ b/src/search/queries/joining/has_child_query.rs
@@ -49,10 +49,14 @@ impl Query {
     /// - `type` - Name of the child relationship mapped for the join field.
     /// - `query` - Query you wish to run on child documents of the `type` field. If a child
     /// document matches the search, the query returns the parent document.
-    pub fn has_child(r#type: impl ToString, query: impl Into<Query>) -> HasChildQuery {
+    pub fn has_child<T, U>(r#type: T, query: U) -> HasChildQuery
+    where
+        T: Into<String>,
+        U: Into<Query>,
+    {
         HasChildQuery {
             inner: Inner {
-                r#type: r#type.to_string(),
+                r#type: r#type.into(),
                 query: Box::new(query.into()),
                 ignore_unmapped: None,
                 max_children: None,
@@ -79,16 +83,16 @@ impl HasChildQuery {
 
     /// Maximum number of child documents that match the `query` allowed for a returned parent
     /// document. If the parent document exceeds this limit, it is excluded from the search results.
-    pub fn max_children(mut self, max_children: impl Into<u32>) -> Self {
-        self.inner.max_children = Some(max_children.into());
+    pub fn max_children(mut self, max_children: u32) -> Self {
+        self.inner.max_children = Some(max_children);
         self
     }
 
     /// Minimum number of child documents that match the `query` required to match the query for a
     /// returned parent document. If the parent document does not meet this limit, it is excluded
     /// from the search results.
-    pub fn min_children(mut self, min_children: impl Into<u32>) -> Self {
-        self.inner.min_children = Some(min_children.into());
+    pub fn min_children(mut self, min_children: u32) -> Self {
+        self.inner.min_children = Some(min_children);
         self
     }
 

--- a/src/search/queries/joining/has_parent_query.rs
+++ b/src/search/queries/joining/has_parent_query.rs
@@ -43,10 +43,14 @@ impl Query {
     /// - `parent-type` - Name of the parent relationship mapped for the join field.
     /// - `query` - Query you wish to run on parent documents of the `parent_type` field. If a
     /// parent document matches the search, the query returns its child documents.
-    pub fn has_parent(parent_type: impl ToString, query: impl Into<Query>) -> HasParentQuery {
+    pub fn has_parent<T, U>(parent_type: T, query: U) -> HasParentQuery
+    where
+        T: Into<String>,
+        U: Into<Query>,
+    {
         HasParentQuery {
             inner: Inner {
-                parent_type: parent_type.to_string(),
+                parent_type: parent_type.into(),
                 query: Box::new(query.into()),
                 score: None,
                 ignore_unmapped: None,

--- a/src/search/queries/joining/nested_query.rs
+++ b/src/search/queries/joining/nested_query.rs
@@ -69,7 +69,11 @@ impl Query {
     /// nesting level, rather than root, if it exists within another nested
     /// query.<br>
     /// Multi-level nested queries are also supported.
-    pub fn nested(path: impl Into<String>, query: impl Into<Query>) -> NestedQuery {
+    pub fn nested<T, U>(path: T, query: U) -> NestedQuery
+    where
+        T: Into<String>,
+        U: Into<Query>,
+    {
         NestedQuery {
             inner: Inner {
                 path: path.into(),

--- a/src/search/queries/joining/parent_id_query.rs
+++ b/src/search/queries/joining/parent_id_query.rs
@@ -40,7 +40,11 @@ impl Query {
     /// - `type` - Name of the child relationship mapped for the join field
     /// - `id` - ID of the parent document. The query will return child documents of this
     /// parent document.
-    pub fn parent_id(r#type: impl ToString, id: impl ToString) -> ParentIdQuery {
+    pub fn parent_id<T, U>(r#type: T, id: U) -> ParentIdQuery
+    where
+        T: ToString,
+        U: ToString,
+    {
         ParentIdQuery {
             inner: Inner {
                 r#type: r#type.to_string(),

--- a/src/search/queries/params/function_score_query.rs
+++ b/src/search/queries/params/function_score_query.rs
@@ -125,7 +125,10 @@ impl Function {
     /// Creates an instance of [FieldValueFactor](FieldValueFactor)
     ///
     /// - `field` - Field to be extracted from the document.
-    pub fn field_value_factor(field: impl Into<String>) -> FieldValueFactor {
+    pub fn field_value_factor<T>(field: T) -> FieldValueFactor
+    where
+        T: Into<String>,
+    {
         FieldValueFactor::new(field)
     }
 
@@ -141,19 +144,26 @@ impl Function {
     /// computed score will equal `decay` parameter. For geo fields: Can be defined as number+unit
     /// (1km, 12m,…​). Default unit is meters. For date fields: Can to be defined as a number+unit
     /// ("1h", "10d",…​). Default unit is milliseconds. For numeric field: Any number.
-    pub fn decay<T: Origin>(
+    pub fn decay<T, O>(
         function: DecayFunction,
-        field: impl Into<String>,
-        origin: T,
-        scale: <T as Origin>::Scale,
-    ) -> Decay<T> {
+        field: T,
+        origin: O,
+        scale: <O as Origin>::Scale,
+    ) -> Decay<O>
+    where
+        T: Into<String>,
+        O: Origin,
+    {
         Decay::new(function, field, origin, scale)
     }
 
     /// Creates an instance of script
     ///
     /// - `source` - script source
-    pub fn script(source: impl Into<String>) -> Script {
+    pub fn script<T>(source: T) -> Script
+    where
+        T: Into<String>,
+    {
         Script::new(source)
     }
 }
@@ -210,13 +220,19 @@ impl RandomScore {
     }
 
     /// Sets seed value
-    pub fn seed(mut self, seed: impl Into<Term>) -> Self {
+    pub fn seed<T>(mut self, seed: T) -> Self
+    where
+        T: Into<Term>,
+    {
         self.random_score.seed = seed.into();
         self
     }
 
     /// Sets field value
-    pub fn field(mut self, field: impl Into<String>) -> Self {
+    pub fn field<T>(mut self, field: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.random_score.field = Some(field.into());
         self
     }
@@ -266,7 +282,10 @@ impl FieldValueFactor {
     /// Creates an instance of [FieldValueFactor](FieldValueFactor)
     ///
     /// - `field` - Field to be extracted from the document.
-    pub fn new(field: impl Into<String>) -> Self {
+    pub fn new<T>(field: T) -> Self
+    where
+        T: Into<String>,
+    {
         Self {
             field_value_factor: FieldValueFactorInner {
                 field: field.into(),
@@ -393,19 +412,25 @@ struct DecayFieldInner<T: Origin> {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-struct DecayInner<T: Origin> {
-    origin: T,
+struct DecayInner<O>
+where
+    O: Origin,
+{
+    origin: O,
 
-    scale: <T as Origin>::Scale,
+    scale: <O as Origin>::Scale,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    offset: Option<<T as Origin>::Offset>,
+    offset: Option<<O as Origin>::Offset>,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     decay: Option<f32>,
 }
 
-impl<T: Origin> Decay<T> {
+impl<O> Decay<O>
+where
+    O: Origin,
+{
     /// Creates an instance of [Decay](Decay)
     ///
     /// - `function` - Decay function variant
@@ -418,12 +443,10 @@ impl<T: Origin> Decay<T> {
     /// computed score will equal `decay` parameter. For geo fields: Can be defined as number+unit
     /// (1km, 12m,…​). Default unit is meters. For date fields: Can to be defined as a number+unit
     /// ("1h", "10d",…​). Default unit is milliseconds. For numeric field: Any number.
-    pub fn new(
-        function: DecayFunction,
-        field: impl Into<String>,
-        origin: T,
-        scale: <T as Origin>::Scale,
-    ) -> Self {
+    pub fn new<T>(function: DecayFunction, field: T, origin: O, scale: <O as Origin>::Scale) -> Self
+    where
+        T: Into<String>,
+    {
         Self {
             function,
             inner: DecayFieldInner {
@@ -442,7 +465,7 @@ impl<T: Origin> Decay<T> {
     /// documents with a distance greater than the defined `offset`.
     ///
     /// The default is `0`.
-    pub fn offset(mut self, offset: <T as Origin>::Offset) -> Self {
+    pub fn offset(mut self, offset: <O as Origin>::Offset) -> Self {
         self.inner.inner.offset = Some(offset);
         self
     }
@@ -522,7 +545,10 @@ impl Script {
     /// Creates an instance of [Script]
     ///
     /// - `source` - script source
-    pub fn new(source: impl Into<String>) -> Self {
+    pub fn new<T>(source: T) -> Self
+    where
+        T: Into<String>,
+    {
         Self {
             script_score: ScriptInnerWrapper {
                 script: ScriptInner {

--- a/src/search/queries/params/inner_hits.rs
+++ b/src/search/queries/params/inner_hits.rs
@@ -1,6 +1,5 @@
 use crate::search::*;
 use crate::util::*;
-use std::convert::TryInto;
 
 /// The [parent-join](https://www.elastic.co/guide/en/elasticsearch/reference/current/parent-join.html)
 /// and [nested](https://www.elastic.co/guide/en/elasticsearch/reference/current/nested.html)
@@ -45,7 +44,10 @@ impl InnerHits {
     }
 
     /// Indicates which source fields are returned for matching documents
-    pub fn source(mut self, source: impl Into<SourceFilter>) -> Self {
+    pub fn source<T>(mut self, source: T) -> Self
+    where
+        T: Into<SourceFilter>,
+    {
         self._source = Some(source.into());
         self
     }
@@ -53,31 +55,33 @@ impl InnerHits {
     /// Starting document offset.
     ///
     /// Defaults to `0`.
-    pub fn from(mut self, from: impl TryInto<u64>) -> Self {
-        if let Ok(from) = from.try_into() {
-            self.from = Some(from);
-        }
+    pub fn from(mut self, from: u64) -> Self {
+        self.from = Some(from);
         self
     }
 
     /// The number of hits to return.
     ///
     /// Defaults to `10`.
-    pub fn size(mut self, size: impl TryInto<u64>) -> Self {
-        if let Ok(size) = size.try_into() {
-            self.size = Some(size);
-        }
+    pub fn size(mut self, size: u64) -> Self {
+        self.size = Some(size);
         self
     }
 
     /// A collection of sorting fields
-    pub fn sort(mut self, sort: impl Into<Vec<Sort>>) -> Self {
+    pub fn sort<T>(mut self, sort: T) -> Self
+    where
+        T: Into<Vec<Sort>>,
+    {
         self.sort.extend(sort.into());
         self
     }
 
     /// Highlight
-    pub fn highlight(mut self, highlight: impl Into<Highlight>) -> Self {
+    pub fn highlight<T>(mut self, highlight: T) -> Self
+    where
+        T: Into<Highlight>,
+    {
         self.highlight = Some(highlight.into());
         self
     }

--- a/src/search/queries/params/terms_set_query.rs
+++ b/src/search/queries/params/terms_set_query.rs
@@ -67,7 +67,10 @@ impl<'a> From<&'a str> for TermsSetScript {
 
 impl TermsSetScript {
     /// Creates an instance of [TermsSetScript]
-    pub fn new(source: impl Into<String>) -> Self {
+    pub fn new<T>(source: T) -> Self
+    where
+        T: Into<String>,
+    {
         Self {
             source: source.into(),
             params: None,

--- a/src/search/queries/specialized/distance_feature_query.rs
+++ b/src/search/queries/specialized/distance_feature_query.rs
@@ -91,13 +91,19 @@ impl Origin for GeoPoint {
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-distance-feature-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
-pub struct DistanceFeatureQuery<O: Origin> {
+pub struct DistanceFeatureQuery<O>
+where
+    O: Origin,
+{
     #[serde(rename = "distance_feature")]
     inner: Inner<O>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner<O: Origin> {
+struct Inner<O>
+where
+    O: Origin,
+{
     field: String,
 
     origin: O,
@@ -145,11 +151,15 @@ impl Query {
     /// field, the `pivot` value must be a
     /// [distance unit](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#distance-units)
     /// , such as `1km` or `12m`.
-    pub fn distance_feature<O: Origin>(
-        field: impl Into<String>,
+    pub fn distance_feature<T, O>(
+        field: T,
         origin: O,
         pivot: <O as Origin>::Pivot,
-    ) -> DistanceFeatureQuery<O> {
+    ) -> DistanceFeatureQuery<O>
+    where
+        T: Into<String>,
+        O: Origin,
+    {
         DistanceFeatureQuery {
             inner: Inner {
                 field: field.into(),
@@ -162,11 +172,14 @@ impl Query {
     }
 }
 
-impl<O: Origin> DistanceFeatureQuery<O> {
+impl<O> DistanceFeatureQuery<O>
+where
+    O: Origin,
+{
     add_boost_and_name!();
 }
 
-impl<O: Origin> ShouldSkip for DistanceFeatureQuery<O> {}
+impl<O> ShouldSkip for DistanceFeatureQuery<O> where O: Origin {}
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/more_like_this_query.rs
+++ b/src/search/queries/specialized/more_like_this_query.rs
@@ -159,7 +159,10 @@ impl Document {
     /// Creates an instance of [Document](Document)
     ///
     /// - `id` - document id as string.
-    pub fn new(id: impl Into<String>) -> Self {
+    pub fn new<T>(id: T) -> Self
+    where
+        T: Into<String>,
+    {
         Self {
             _id: id.into(),
             _stored_fields: BTreeSet::new(),
@@ -170,33 +173,39 @@ impl Document {
     }
 
     /// The index that contains the document. Required if no index is specified in the request URI.
-    pub fn index(mut self, index: impl Into<String>) -> Self {
+    pub fn index<T>(mut self, index: T) -> Self
+    where
+        T: Into<String>,
+    {
         self._index = Some(index.into());
         self
     }
 
     /// The key for the primary shard the document resides on. Required if routing is used during indexing.
-    pub fn routing(mut self, routing: impl Into<String>) -> Self {
+    pub fn routing<T>(mut self, routing: T) -> Self
+    where
+        T: Into<String>,
+    {
         self._routing = Some(routing.into());
         self
     }
 
     /// If `false`, excludes all `_source` fields. Defaults to `true`.
-    pub fn source(mut self, source: impl Into<SourceFilter>) -> Self {
+    pub fn source<T>(mut self, source: T) -> Self
+    where
+        T: Into<SourceFilter>,
+    {
         self._source = Some(source.into());
         self
     }
 
     /// The stored fields you want to retrieve.
-    pub fn stored_fields<I>(mut self, stored_fields: I) -> Self
+    pub fn stored_fields<T>(mut self, stored_fields: T) -> Self
     where
-        I: IntoIterator,
-        I::Item: ToString,
+        T: IntoIterator,
+        T::Item: Into<String>,
     {
-        self._stored_fields = stored_fields
-            .into_iter()
-            .map(|value| value.to_string())
-            .collect();
+        self._stored_fields = stored_fields.into_iter().map(Into::into).collect();
         self
     }
 }
@@ -261,52 +270,52 @@ impl MoreLikeThisQuery {
     /// The maximum number of query terms that will be selected.
     /// Increasing this value gives greater accuracy at the expense of query execution speed.
     /// Defaults to 25.
-    pub fn max_query_terms(mut self, max_query_terms: impl Into<i64>) -> Self {
-        self.inner.max_query_terms = Some(max_query_terms.into());
+    pub fn max_query_terms(mut self, max_query_terms: i64) -> Self {
+        self.inner.max_query_terms = Some(max_query_terms);
         self
     }
 
     /// The minimum term frequency below which the terms will be ignored from the input document.
     /// Defaults to 2.
-    pub fn min_term_freq(mut self, min_term_freq: impl Into<i64>) -> Self {
-        self.inner.min_term_freq = Some(min_term_freq.into());
+    pub fn min_term_freq(mut self, min_term_freq: i64) -> Self {
+        self.inner.min_term_freq = Some(min_term_freq);
         self
     }
 
     /// The minimum document frequency below which the terms will be ignored from the input document.
     /// Defaults to 5.
-    pub fn min_doc_freq(mut self, min_doc_freq: impl Into<i64>) -> Self {
-        self.inner.min_doc_freq = Some(min_doc_freq.into());
+    pub fn min_doc_freq(mut self, min_doc_freq: i64) -> Self {
+        self.inner.min_doc_freq = Some(min_doc_freq);
         self
     }
 
     /// The maximum document frequency above which the terms will be ignored from the input document.
     /// This could be useful in order to ignore highly frequent words such as stop words.
     /// Defaults to unbounded (Integer.MAX_VALUE, which is 2^31-1 or 2147483647).
-    pub fn max_doc_freq(mut self, max_doc_freq: impl Into<i64>) -> Self {
-        self.inner.max_doc_freq = Some(max_doc_freq.into());
+    pub fn max_doc_freq(mut self, max_doc_freq: i64) -> Self {
+        self.inner.max_doc_freq = Some(max_doc_freq);
         self
     }
 
     /// The minimum word length below which the terms will be ignored. Defaults to 0.
-    pub fn min_word_length(mut self, min_word_length: impl Into<i64>) -> Self {
-        self.inner.min_word_length = Some(min_word_length.into());
+    pub fn min_word_length(mut self, min_word_length: i64) -> Self {
+        self.inner.min_word_length = Some(min_word_length);
         self
     }
 
     /// The maximum word length above which the terms will be ignored. Defaults to unbounded (0).
-    pub fn max_word_length(mut self, max_word_length: impl Into<i64>) -> Self {
-        self.inner.max_word_length = Some(max_word_length.into());
+    pub fn max_word_length(mut self, max_word_length: i64) -> Self {
+        self.inner.max_word_length = Some(max_word_length);
         self
     }
 
     /// An array of stop words. Any word in this set is considered "uninteresting" and ignored.
     /// If the analyzer allows for stop words, you might want to tell MLT to explicitly ignore them,
     /// as for the purposes of document similarity it seems reasonable to assume that "a stop word is never interesting".
-    pub fn stop_words<I>(mut self, stop_words: I) -> Self
+    pub fn stop_words<T>(mut self, stop_words: T) -> Self
     where
-        I: IntoIterator,
-        I::Item: Into<String>,
+        T: IntoIterator,
+        T::Item: Into<String>,
     {
         self.inner.stop_words = Some(stop_words.into_iter().map(Into::into).collect());
         self
@@ -314,35 +323,44 @@ impl MoreLikeThisQuery {
 
     /// The analyzer that is used to analyze the free form text.
     /// Defaults to the analyzer associated with the first field in `fields`.
-    pub fn analyzer(mut self, analyzer: impl Into<String>) -> Self {
+    pub fn analyzer<T>(mut self, analyzer: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.analyzer = Some(analyzer.into());
         self
     }
 
     /// After the disjunctive query has been formed, this parameter controls the number of terms that must match.
     /// The syntax is the same as the `minimum should match`. (Defaults to "30%").
-    pub fn minimum_should_match(mut self, minimum_should_match: impl Into<String>) -> Self {
+    pub fn minimum_should_match<T>(mut self, minimum_should_match: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.minimum_should_match = Some(minimum_should_match.into());
         self
     }
 
     /// Controls whether the query should fail (throw an exception) if any of the specified fields are not of the supported types (text or keyword).
     /// Set this to false to ignore the field and continue processing. Defaults to true.
-    pub fn fail_on_unsupported_field(mut self, fail_on_unsupported_field: impl Into<bool>) -> Self {
-        self.inner.fail_on_unsupported_field = Some(fail_on_unsupported_field.into());
+    pub fn fail_on_unsupported_field(mut self, fail_on_unsupported_field: bool) -> Self {
+        self.inner.fail_on_unsupported_field = Some(fail_on_unsupported_field);
         self
     }
 
     /// Each term in the formed query could be further boosted by their tf-idf score. This sets the boost factor to use when using this feature.
     /// Defaults to deactivated (0). Any other positive value activates terms boosting with the given boost factor.
-    pub fn boost_terms(mut self, boost_terms: impl Into<f64>) -> Self {
+    pub fn boost_terms<T>(mut self, boost_terms: T) -> Self
+    where
+        T: Into<f64>,
+    {
         self.inner.boost_terms = Some(boost_terms.into());
         self
     }
 
     /// Specifies whether the input documents should also be included in the search results returned. Defaults to `false`.
-    pub fn include(mut self, include: impl Into<bool>) -> Self {
-        self.inner.include = Some(include.into());
+    pub fn include(mut self, include: bool) -> Self {
+        self.inner.include = Some(include);
         self
     }
 

--- a/src/search/queries/specialized/rank_feature_query.rs
+++ b/src/search/queries/specialized/rank_feature_query.rs
@@ -249,7 +249,10 @@ impl Query {
     /// Creates an instance of [`RankFeatureQuery`]
     ///
     /// - `field` - `rank_feature` or `rank_features` field used to boost relevance scores
-    pub fn rank_feature(field: impl Into<String>) -> RankFeatureQuery {
+    pub fn rank_feature<T>(field: T) -> RankFeatureQuery
+    where
+        T: Into<String>,
+    {
         RankFeatureQuery {
             inner: Inner {
                 field: field.into(),
@@ -339,8 +342,11 @@ impl RankFeatureQuery {
 
 impl RankFeatureSaturationQuery {
     /// Sets pivot value
-    pub fn pivot(mut self, pivot: impl Into<Option<f64>>) -> Self {
-        self.inner.saturation.pivot = pivot.into();
+    pub fn pivot<T>(mut self, pivot: T) -> Self
+    where
+        T: Into<f64>,
+    {
+        self.inner.saturation.pivot = Some(pivot.into());
         self
     }
 

--- a/src/search/queries/term_level/exists_query.rs
+++ b/src/search/queries/term_level/exists_query.rs
@@ -44,7 +44,10 @@ impl Query {
     ///   - Empty strings, such as `""` or `"-"`
     ///   - Arrays containing `null` and another value, such as `[null, "foo"]`
     ///   - A custom [`null-value`](https://www.elastic.co/guide/en/elasticsearch/reference/current/null-value.html), defined in field mapping
-    pub fn exists(field: impl Into<String>) -> ExistsQuery {
+    pub fn exists<T>(field: T) -> ExistsQuery
+    where
+        T: Into<String>,
+    {
         ExistsQuery {
             inner: Inner {
                 field: field.into(),

--- a/src/search/queries/term_level/fuzzy_query.rs
+++ b/src/search/queries/term_level/fuzzy_query.rs
@@ -68,7 +68,11 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `value` - Fuzzy you wish to find in the provided field.
-    pub fn fuzzy(field: impl Into<String>, value: impl Into<Term>) -> FuzzyQuery {
+    pub fn fuzzy<T, U>(field: T, value: U) -> FuzzyQuery
+    where
+        T: Into<String>,
+        U: Into<Term>,
+    {
         FuzzyQuery {
             field: field.into(),
             inner: Inner {
@@ -91,7 +95,10 @@ impl FuzzyQuery {
     /// for valid values and more information. See
     /// [Fuzziness in the match query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#query-dsl-match-query-fuzziness)
     /// for an example.
-    pub fn fuzziness(mut self, fuzziness: impl Into<Fuzziness>) -> Self {
+    pub fn fuzziness<T>(mut self, fuzziness: T) -> Self
+    where
+        T: Into<Fuzziness>,
+    {
         self.inner.fuzziness = Some(fuzziness.into());
         self
     }

--- a/src/search/queries/term_level/prefix_query.rs
+++ b/src/search/queries/term_level/prefix_query.rs
@@ -50,7 +50,11 @@ impl Query {
     /// - `field` - Field you wish to search.
     /// - `value` - Term you wish to find in the provided field.
     /// To return a document, the term must exactly match the field value, including whitespace and capitalization.
-    pub fn prefix(field: impl Into<String>, value: impl Into<Term>) -> PrefixQuery {
+    pub fn prefix<T, U>(field: T, value: U) -> PrefixQuery
+    where
+        T: Into<String>,
+        U: Into<Term>,
+    {
         PrefixQuery {
             field: field.into(),
             inner: Inner {

--- a/src/search/queries/term_level/range_query.rs
+++ b/src/search/queries/term_level/range_query.rs
@@ -56,7 +56,10 @@ impl Query {
     /// Creates an instance of [`RangeQuery`]
     ///
     /// - `field` - Field you wish to search.
-    pub fn range(field: impl Into<String>) -> RangeQuery {
+    pub fn range<T>(field: T) -> RangeQuery
+    where
+        T: Into<String>,
+    {
         RangeQuery {
             field: field.into(),
             inner: Inner {
@@ -76,25 +79,37 @@ impl Query {
 
 impl RangeQuery {
     /// Greater than.
-    pub fn gt(mut self, gt: impl Into<Term>) -> Self {
+    pub fn gt<T>(mut self, gt: T) -> Self
+    where
+        T: Into<Term>,
+    {
         self.inner.gt = gt.into();
         self
     }
 
     /// Greater than or equal to.
-    pub fn gte(mut self, gte: impl Into<Term>) -> Self {
+    pub fn gte<T>(mut self, gte: T) -> Self
+    where
+        T: Into<Term>,
+    {
         self.inner.gte = gte.into();
         self
     }
 
     /// Less than.
-    pub fn lt(mut self, lt: impl Into<Term>) -> Self {
+    pub fn lt<T>(mut self, lt: T) -> Self
+    where
+        T: Into<Term>,
+    {
         self.inner.lt = lt.into();
         self
     }
 
     /// Less than or equal to.
-    pub fn lte(mut self, lte: impl Into<Term>) -> Self {
+    pub fn lte<T>(mut self, lte: T) -> Self
+    where
+        T: Into<Term>,
+    {
         self.inner.lte = lte.into();
         self
     }
@@ -111,7 +126,10 @@ impl RangeQuery {
     /// >If a format or date value is incomplete, the range query replaces
     /// any missing components with default values. See
     /// [Missing date components](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html#missing-date-components).
-    pub fn format(mut self, format: impl Into<String>) -> Self {
+    pub fn format<T>(mut self, format: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.format = Some(format.into());
         self
     }
@@ -131,7 +149,10 @@ impl RangeQuery {
     ///
     /// For an example query using the `time_zone` parameter, see
     /// [Time zone in `range` queries](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html#range-query-time-zone).
-    pub fn time_zone(mut self, time_zone: impl Into<String>) -> Self {
+    pub fn time_zone<T>(mut self, time_zone: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.inner.time_zone = Some(time_zone.into());
         self
     }

--- a/src/search/queries/term_level/term_query.rs
+++ b/src/search/queries/term_level/term_query.rs
@@ -46,7 +46,11 @@ impl Query {
     /// - `field` - Field you wish to search.
     /// - `value` - Term you wish to find in the provided field.
     /// To return a document, the term must exactly match the field value, including whitespace and capitalization.
-    pub fn term(field: impl Into<String>, value: impl Into<Term>) -> TermQuery {
+    pub fn term<T, U>(field: T, value: U) -> TermQuery
+    where
+        T: Into<String>,
+        U: Into<Term>,
+    {
         TermQuery {
             field: field.into(),
             inner: Inner {

--- a/src/search/queries/term_level/wildcard_query.rs
+++ b/src/search/queries/term_level/wildcard_query.rs
@@ -45,7 +45,11 @@ impl Query {
     /// - `field` - Field you wish to search.
     /// - `value` - Wildcard you wish to find in the provided field.
     /// To return a document, the wildcard must exactly match the field value, including whitespace and capitalization.
-    pub fn wildcard(field: impl Into<String>, value: impl Into<Term>) -> WildcardQuery {
+    pub fn wildcard<T, U>(field: T, value: U) -> WildcardQuery
+    where
+        T: Into<String>,
+        U: Into<Term>,
+    {
         WildcardQuery {
             field: field.into(),
             inner: Inner {

--- a/src/search/rescoring/mod.rs
+++ b/src/search/rescoring/mod.rs
@@ -3,7 +3,6 @@
 
 use crate::search::*;
 use crate::util::*;
-use std::convert::TryInto;
 
 /// Rescoring can help to improve precision by reordering just the top (eg 100 - 500)
 /// documents returned by the [query](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#request-body-search-query)
@@ -57,7 +56,10 @@ impl Rescore {
     /// Creates a new instance of [`Rescore`]
     ///
     /// - `query` - Second query which will be execute on top-k results returned by original query.
-    pub fn new(query: impl Into<Option<Query>>) -> Self {
+    pub fn new<T>(query: T) -> Self
+    where
+        T: Into<Option<Query>>,
+    {
         Self {
             query: Inner {
                 rescore_query: query.into(),
@@ -69,21 +71,25 @@ impl Rescore {
     }
 
     /// The number of docs which will be examined on each shard can be controlled by the `window_size` parameter, which defaults to 10.
-    pub fn window_size(mut self, window_size: impl TryInto<u64>) -> Self {
-        if let Ok(window_size) = window_size.try_into() {
-            self.window_size = Some(window_size);
-        }
+    pub fn window_size(mut self, window_size: u64) -> Self {
+        self.window_size = Some(window_size);
         self
     }
 
     /// The relative importance of the rescore query can be controlled with the `rescore_query_weight` respectively. Both default to 1.
-    pub fn rescore_query_weight(mut self, rescore_query_weight: impl Into<f64>) -> Self {
+    pub fn rescore_query_weight<T>(mut self, rescore_query_weight: T) -> Self
+    where
+        T: Into<f64>,
+    {
         self.query.rescore_query_weight = Some(rescore_query_weight.into());
         self
     }
 
     /// The relative importance of the original query can be controlled with the `query_weight` respectively. Both default to 1.
-    pub fn query_weight(mut self, query_weight: impl Into<f64>) -> Self {
+    pub fn query_weight<T>(mut self, query_weight: T) -> Self
+    where
+        T: Into<f64>,
+    {
         self.query.query_weight = Some(query_weight.into());
         self
     }

--- a/src/search/sort/mod.rs
+++ b/src/search/sort/mod.rs
@@ -158,7 +158,10 @@ struct SortInner {
 
 impl Sort {
     /// Creates an instance of [`Sort`]
-    pub fn new(field: impl Into<SortField>) -> Self {
+    pub fn new<T>(field: T) -> Self
+    where
+        T: Into<SortField>,
+    {
         Self(KeyValuePair::new(field.into(), Default::default()))
     }
 
@@ -181,7 +184,10 @@ impl Sort {
     /// Fallback type if mapping is not defined
     ///
     /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#_ignoring_unmapped_fields>
-    pub fn unmapped_type(mut self, unmapped_type: impl Into<String>) -> Self {
+    pub fn unmapped_type<T>(mut self, unmapped_type: T) -> Self
+    where
+        T: Into<String>,
+    {
         self.0.value.unmapped_type = Some(unmapped_type.into());
         self
     }
@@ -189,7 +195,10 @@ impl Sort {
     /// The missing parameter specifies how docs which are missing the sort field should be treated
     ///
     /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#_missing_values>
-    pub fn missing(mut self, missing: impl Into<SortMissing>) -> Self {
+    pub fn missing<T>(mut self, missing: T) -> Self
+    where
+        T: Into<SortMissing>,
+    {
         self.0.value.missing = Some(missing.into());
         self
     }


### PR DESCRIPTION
The codebase had a mix of implicit impl blocks as well as explicit ones. This makes things consistent. Later I'll check if it is possible to configure clippy about such rules.