### PR TITLE
Use consistent rename_all

### DIFF
--- a/src/search/highlight/encoder.rs
+++ b/src/search/highlight/encoder.rs
@@ -1,6 +1,6 @@
 /// Indicates if the snippet should be HTML encoded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(untagged, rename_all = "lowercase")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum Encoder {
     /// No encoding
     Default,

--- a/src/search/highlight/fragmenter.rs
+++ b/src/search/highlight/fragmenter.rs
@@ -1,6 +1,6 @@
 /// Specifies how text should be broken up in highlight snippets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(untagged, rename_all = "lowercase")]
+#[serde(untagged, rename_all = "snake_case")]
 pub enum Fragmenter {
     /// Breaks up text into same-sized fragments.
     Simple,

--- a/src/search/highlight/order.rs
+++ b/src/search/highlight/order.rs
@@ -6,7 +6,7 @@
 /// [How highlighters work internally](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#how-es-highlighters-work-internally)
 /// for more details how different highlighters find the best fragments.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum Order {
     /// Sorts highlighted fragments by score.
     Score,

--- a/src/search/params/units.rs
+++ b/src/search/params/units.rs
@@ -40,7 +40,7 @@ impl Serialize for Time {
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#calendar_intervals>
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum CalendarInterval {
     /// All minutes begin at 00 seconds. One minute is the interval between 00 seconds of the first
     /// minute and 00 seconds of the following minute in the specified time zone, compensating for

--- a/src/search/queries/params/function_score_query.rs
+++ b/src/search/queries/params/function_score_query.rs
@@ -7,7 +7,7 @@ use std::fmt::Debug;
 /// Each document is scored by the defined functions. The parameter `score_mode` specifies how
 /// the computed scores are combined
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum FunctionScoreMode {
     /// Scores are multiplied (default)
     Multiply,
@@ -37,7 +37,7 @@ impl Default for FunctionScoreMode {
 /// The newly computed score is combined with the score of the query. The parameter
 /// `boost_mode` defines how.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum FunctionScoreBoostMode {
     /// Query score and function score is multiplied (default)
     Multiply,
@@ -320,7 +320,7 @@ impl FieldValueFactor {
 ///
 /// Defaults to [none](FieldValueFactorModifier::None)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum FieldValueFactorModifier {
     /// Do not apply any multiplier to the field value
     None,
@@ -508,7 +508,7 @@ impl<T: Origin> Serialize for DecayFieldInner<T> {
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#_supported_decay_functions>
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum DecayFunction {
     /// Linear decay
     Linear,

--- a/src/search/queries/params/has_child_query.rs
+++ b/src/search/queries/params/has_child_query.rs
@@ -1,7 +1,7 @@
 /// Indicates how scores for matching child documents affect the root parent document’s relevance
 /// score.
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum HasChildScoreMode {
     /// Do not use the relevance scores of matching child documents. The query assigns parent
     /// documents a score of 0.

--- a/src/search/queries/params/zero_terms_query.rs
+++ b/src/search/queries/params/zero_terms_query.rs
@@ -1,7 +1,7 @@
 /// Indicates whether no documents are returned if the `analyzer` removes all
 /// tokens, such as when using a `stop` filter.
 #[derive(Debug, Clone, PartialEq, Serialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum ZeroTermsQuery {
     /// No documents are returned if the `analyzer` removes all tokens.
     None,


### PR DESCRIPTION
snake case will cover lowercase variant too and will be more consistent within the project.