### PR TITLE
Simplify query serialization

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,6 +117,7 @@ extern crate serde_json;
 mod macros;
 
 // Crate modules
+#[macro_use]
 pub(crate) mod util;
 
 // Public modules

--- a/src/search/queries/compound/bool_query.rs
+++ b/src/search/queries/compound/bool_query.rs
@@ -26,26 +26,27 @@ use crate::util::*;
 ///    .name("test");
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html>
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct BoolQuery {
-    #[serde(rename = "bool")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
-struct Inner {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     must: Queries,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     filter: Queries,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     should: Queries,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     must_not: Queries,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     minimum_should_match: Option<MinimumShouldMatch>,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     boost: Option<Boost>,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     _name: Option<String>,
 }
@@ -63,7 +64,7 @@ impl BoolQuery {
     where
         Q: Into<Queries>,
     {
-        self.inner.must.extend(queries);
+        self.must.extend(queries);
         self
     }
 
@@ -72,7 +73,7 @@ impl BoolQuery {
     where
         Q: Into<Queries>,
     {
-        self.inner.should.extend(queries);
+        self.should.extend(queries);
         self
     }
 
@@ -84,7 +85,7 @@ impl BoolQuery {
     where
         Q: Into<Queries>,
     {
-        self.inner.filter.extend(queries);
+        self.filter.extend(queries);
         self
     }
 
@@ -96,7 +97,7 @@ impl BoolQuery {
     where
         Q: Into<Queries>,
     {
-        self.inner.must_not.extend(queries);
+        self.must_not.extend(queries);
         self
     }
 
@@ -113,7 +114,7 @@ impl BoolQuery {
     where
         S: Into<MinimumShouldMatch>,
     {
-        self.inner.minimum_should_match = Some(minimum_should_match.into());
+        self.minimum_should_match = Some(minimum_should_match.into());
         self
     }
 
@@ -122,12 +123,14 @@ impl BoolQuery {
 
 impl ShouldSkip for BoolQuery {
     fn should_skip(&self) -> bool {
-        self.inner.must.should_skip()
-            && self.inner.filter.should_skip()
-            && self.inner.should.should_skip()
-            && self.inner.must_not.should_skip()
+        self.must.should_skip()
+            && self.filter.should_skip()
+            && self.should.should_skip()
+            && self.must_not.should_skip()
     }
 }
+
+serialize_query!("bool": BoolQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/compound/boosting_query.rs
+++ b/src/search/queries/compound/boosting_query.rs
@@ -18,18 +18,17 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-boosting-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct BoostingQuery {
-    #[serde(rename = "boosting")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     positive: Box<Query>,
+
     negative: Box<Query>,
+
     negative_boost: NegativeBoost,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     boost: Option<Boost>,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     _name: Option<String>,
 }
@@ -56,13 +55,11 @@ impl Query {
         B: Into<NegativeBoost>,
     {
         BoostingQuery {
-            inner: Inner {
-                positive: Box::new(positive.into()),
-                negative: Box::new(negative.into()),
-                negative_boost: negative_boost.into(),
-                boost: None,
-                _name: None,
-            },
+            positive: Box::new(positive.into()),
+            negative: Box::new(negative.into()),
+            negative_boost: negative_boost.into(),
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -73,9 +70,11 @@ impl BoostingQuery {
 
 impl ShouldSkip for BoostingQuery {
     fn should_skip(&self) -> bool {
-        self.inner.positive.should_skip() || self.inner.negative.should_skip()
+        self.positive.should_skip() || self.negative.should_skip()
     }
 }
+
+serialize_query!("boosting": BoostingQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/compound/constant_score_query.rs
+++ b/src/search/queries/compound/constant_score_query.rs
@@ -17,13 +17,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-constant-score-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct ConstantScoreQuery {
-    #[serde(rename = "constant_score")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     filter: Box<Query>,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
@@ -46,11 +41,9 @@ impl Query {
         T: Into<Query>,
     {
         ConstantScoreQuery {
-            inner: Inner {
-                filter: Box::new(filter.into()),
-                boost: None,
-                _name: None,
-            },
+            filter: Box::new(filter.into()),
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -61,9 +54,11 @@ impl ConstantScoreQuery {
 
 impl ShouldSkip for ConstantScoreQuery {
     fn should_skip(&self) -> bool {
-        self.inner.filter.should_skip()
+        self.filter.should_skip()
     }
 }
+
+serialize_query!("constant_score": ConstantScoreQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/compound/dis_max_query.rs
+++ b/src/search/queries/compound/dis_max_query.rs
@@ -24,14 +24,9 @@ use crate::util::*;
 ///     .name("test");
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-dis-max-query.html>
-#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct DisMaxQuery {
-    #[serde(rename = "dis_max")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Serialize)]
-struct Inner {
     queries: Queries,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
@@ -60,7 +55,7 @@ impl DisMaxQuery {
     where
         Q: Into<Queries>,
     {
-        self.inner.queries.extend(queries);
+        self.queries.extend(queries);
         self
     }
 
@@ -87,7 +82,7 @@ impl DisMaxQuery {
         T: std::convert::TryInto<TieBreaker>,
     {
         if let Ok(tie_breaker) = tie_breaker.try_into() {
-            self.inner.tie_breaker = Some(tie_breaker);
+            self.tie_breaker = Some(tie_breaker);
         }
         self
     }
@@ -97,9 +92,11 @@ impl DisMaxQuery {
 
 impl ShouldSkip for DisMaxQuery {
     fn should_skip(&self) -> bool {
-        self.inner.queries.should_skip()
+        self.queries.should_skip()
     }
 }
+
+serialize_query!("dis_max": DisMaxQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/combined_fields_query.rs
+++ b/src/search/queries/full_text/combined_fields_query.rs
@@ -17,14 +17,9 @@ use crate::util::*;
 ///     .name("test");
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-combined-fields-query.html>
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct CombinedFieldsQuery {
-    #[serde(rename = "combined_fields")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
-struct Inner {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     fields: Vec<String>,
 
@@ -65,16 +60,14 @@ impl Query {
         S: Into<Text>,
     {
         CombinedFieldsQuery {
-            inner: Inner {
-                fields: fields.into_iter().map(|s| s.to_string()).collect(),
-                query: query.into(),
-                auto_generate_synonyms_phrase_query: None,
-                operator: None,
-                minimum_should_match: None,
-                zero_terms_query: None,
-                boost: None,
-                _name: None,
-            },
+            fields: fields.into_iter().map(|s| s.to_string()).collect(),
+            query: query.into(),
+            auto_generate_synonyms_phrase_query: None,
+            operator: None,
+            minimum_should_match: None,
+            zero_terms_query: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -90,13 +83,13 @@ impl CombinedFieldsQuery {
         mut self,
         auto_generate_synonyms_phrase_query: bool,
     ) -> Self {
-        self.inner.auto_generate_synonyms_phrase_query = Some(auto_generate_synonyms_phrase_query);
+        self.auto_generate_synonyms_phrase_query = Some(auto_generate_synonyms_phrase_query);
         self
     }
 
     /// Boolean logic used to interpret text in the `query` value
     pub fn operator(mut self, operator: Operator) -> Self {
-        self.inner.operator = Some(operator);
+        self.operator = Some(operator);
         self
     }
 
@@ -108,14 +101,14 @@ impl CombinedFieldsQuery {
     where
         T: Into<MinimumShouldMatch>,
     {
-        self.inner.minimum_should_match = Some(minimum_should_match.into());
+        self.minimum_should_match = Some(minimum_should_match.into());
         self
     }
 
     /// Indicates whether no documents are returned if the `analyzer` removes
     /// all tokens, such as when using a `stop` filter.
     pub fn zero_terms_query(mut self, zero_terms_query: ZeroTermsQuery) -> Self {
-        self.inner.zero_terms_query = Some(zero_terms_query);
+        self.zero_terms_query = Some(zero_terms_query);
         self
     }
 
@@ -124,9 +117,11 @@ impl CombinedFieldsQuery {
 
 impl ShouldSkip for CombinedFieldsQuery {
     fn should_skip(&self) -> bool {
-        self.inner.fields.should_skip() || self.inner.query.should_skip()
+        self.fields.should_skip() || self.query.should_skip()
     }
 }
+
+serialize_query!("combined_fields": CombinedFieldsQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/match_phrase_query.rs
+++ b/src/search/queries/full_text/match_phrase_query.rs
@@ -1,6 +1,5 @@
 use crate::search::*;
 use crate::util::*;
-use serde::ser::{Serialize, SerializeStruct, Serializer};
 
 /// The `match_phrase` query analyzes the text and creates a phrase query out
 /// of the analyzed text.
@@ -15,14 +14,12 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 ///     .name("test");
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query-phrase.html>
-#[derive(Debug, Clone, PartialEq)]
-pub struct MatchPhraseQuery {
-    field: String,
-    inner: Inner,
-}
-
 #[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
+#[serde(remote = "Self")]
+pub struct MatchPhraseQuery {
+    #[serde(skip)]
+    field: String,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     query: Text,
 
@@ -58,13 +55,11 @@ impl Query {
     {
         MatchPhraseQuery {
             field: field.into(),
-            inner: Inner {
-                query: query.into(),
-                analyzer: None,
-                slop: None,
-                boost: None,
-                _name: None,
-            },
+            query: query.into(),
+            analyzer: None,
+            slop: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -78,14 +73,14 @@ impl MatchPhraseQuery {
     where
         T: Into<String>,
     {
-        self.inner.analyzer = Some(analyzer.into());
+        self.analyzer = Some(analyzer.into());
         self
     }
 
     /// The maximum number of intervening unmatched positions, as well as
     /// whether matches are required to be in-order.
     pub fn slop(mut self, slop: u8) -> Self {
-        self.inner.slop = Some(slop);
+        self.slop = Some(slop);
         self
     }
 
@@ -94,23 +89,11 @@ impl MatchPhraseQuery {
 
 impl ShouldSkip for MatchPhraseQuery {
     fn should_skip(&self) -> bool {
-        self.inner.query.should_skip()
+        self.query.should_skip()
     }
 }
 
-impl Serialize for MatchPhraseQuery {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        let mut hash = std::collections::HashMap::new();
-        let _ = hash.insert(&self.field, &self.inner);
-
-        let mut map = serializer.serialize_struct("MatchPhraseQuery", 1)?;
-        map.serialize_field("match_phrase", &hash)?;
-        map.end()
-    }
-}
+serialize_query!(keyed, "match_phrase": MatchPhraseQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/multi_match_query.rs
+++ b/src/search/queries/full_text/multi_match_query.rs
@@ -17,13 +17,9 @@ use crate::util::*;
 ///     .name("test");
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html>
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct MultiMatchQuery {
-    #[serde(rename = "multi_match")]
-    inner: Inner,
-}
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
-struct Inner {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     fields: Vec<String>,
 
@@ -94,25 +90,23 @@ impl Query {
         S: Into<Text>,
     {
         MultiMatchQuery {
-            inner: Inner {
-                fields: fields.into_iter().map(|s| s.to_string()).collect(),
-                r#type: None,
-                tie_breaker: None,
-                query: query.into(),
-                analyzer: None,
-                auto_generate_synonyms_phrase_query: None,
-                fuzziness: None,
-                max_expansions: None,
-                prefix_length: None,
-                fuzzy_transpositions: None,
-                fuzzy_rewrite: None,
-                lenient: None,
-                operator: None,
-                minimum_should_match: None,
-                zero_terms_query: None,
-                boost: None,
-                _name: None,
-            },
+            fields: fields.into_iter().map(|s| s.to_string()).collect(),
+            r#type: None,
+            tie_breaker: None,
+            query: query.into(),
+            analyzer: None,
+            auto_generate_synonyms_phrase_query: None,
+            fuzziness: None,
+            max_expansions: None,
+            prefix_length: None,
+            fuzzy_transpositions: None,
+            fuzzy_rewrite: None,
+            lenient: None,
+            operator: None,
+            minimum_should_match: None,
+            zero_terms_query: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -121,11 +115,11 @@ impl MultiMatchQuery {
     /// The way the multi_match query is executed internally depends on the
     /// type parameter
     pub fn r#type(mut self, r#type: MultiMatchQueryType) -> Self {
-        self.inner.r#type = Some(r#type);
+        self.r#type = Some(r#type);
 
         match r#type {
-            MultiMatchQueryType::BestFields(tie_breaker) => self.inner.tie_breaker = tie_breaker,
-            _ => self.inner.tie_breaker = None,
+            MultiMatchQueryType::BestFields(tie_breaker) => self.tie_breaker = tie_breaker,
+            _ => self.tie_breaker = None,
         }
         self
     }
@@ -138,7 +132,7 @@ impl MultiMatchQuery {
     where
         T: Into<String>,
     {
-        self.inner.analyzer = Some(analyzer.into());
+        self.analyzer = Some(analyzer.into());
         self
     }
 
@@ -152,7 +146,7 @@ impl MultiMatchQuery {
         mut self,
         auto_generate_synonyms_phrase_query: bool,
     ) -> Self {
-        self.inner.auto_generate_synonyms_phrase_query = Some(auto_generate_synonyms_phrase_query);
+        self.auto_generate_synonyms_phrase_query = Some(auto_generate_synonyms_phrase_query);
         self
     }
 
@@ -165,28 +159,28 @@ impl MultiMatchQuery {
     where
         T: Into<Fuzziness>,
     {
-        self.inner.fuzziness = Some(fuzziness.into());
+        self.fuzziness = Some(fuzziness.into());
         self
     }
 
     /// Maximum number of terms to which the query will expand.
     /// Defaults to `50`.
     pub fn max_expansions(mut self, max_expansions: u8) -> Self {
-        self.inner.max_expansions = Some(max_expansions);
+        self.max_expansions = Some(max_expansions);
         self
     }
 
     /// Number of beginning characters left unchanged for fuzzy matching.
     /// Defaults to `0`.
     pub fn prefix_length(mut self, prefix_length: u8) -> Self {
-        self.inner.prefix_length = Some(prefix_length);
+        self.prefix_length = Some(prefix_length);
         self
     }
 
     /// If `true`, edits for fuzzy matching include transpositions of two
     /// adjacent characters (ab → ba). Defaults to `true`.
     pub fn fuzzy_transpositions(mut self, fuzzy_transpositions: bool) -> Self {
-        self.inner.fuzzy_transpositions = Some(fuzzy_transpositions);
+        self.fuzzy_transpositions = Some(fuzzy_transpositions);
         self
     }
 
@@ -198,7 +192,7 @@ impl MultiMatchQuery {
     /// `fuzzy_rewrite` method of `top_terms_blended_freqs_${max_expansions}`
     /// by default.
     pub fn fuzzy_rewrite(mut self, fuzzy_rewrite: Rewrite) -> Self {
-        self.inner.fuzzy_rewrite = Some(fuzzy_rewrite);
+        self.fuzzy_rewrite = Some(fuzzy_rewrite);
         self
     }
 
@@ -207,13 +201,13 @@ impl MultiMatchQuery {
     /// [numeric](https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html)
     /// field, are ignored. Defaults to `false`.
     pub fn lenient(mut self, lenient: bool) -> Self {
-        self.inner.lenient = Some(lenient);
+        self.lenient = Some(lenient);
         self
     }
 
     /// Boolean logic used to interpret text in the `query` value
     pub fn operator(mut self, operator: Operator) -> Self {
-        self.inner.operator = Some(operator);
+        self.operator = Some(operator);
         self
     }
 
@@ -225,14 +219,14 @@ impl MultiMatchQuery {
     where
         T: Into<MinimumShouldMatch>,
     {
-        self.inner.minimum_should_match = Some(minimum_should_match.into());
+        self.minimum_should_match = Some(minimum_should_match.into());
         self
     }
 
     /// Indicates whether no documents are returned if the `analyzer` removes
     /// all tokens, such as when using a `stop` filter.
     pub fn zero_terms_query(mut self, zero_terms_query: ZeroTermsQuery) -> Self {
-        self.inner.zero_terms_query = Some(zero_terms_query);
+        self.zero_terms_query = Some(zero_terms_query);
         self
     }
 
@@ -241,9 +235,11 @@ impl MultiMatchQuery {
 
 impl ShouldSkip for MultiMatchQuery {
     fn should_skip(&self) -> bool {
-        self.inner.query.should_skip()
+        self.query.should_skip()
     }
 }
+
+serialize_query!("multi_match": MultiMatchQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/query_string_query.rs
+++ b/src/search/queries/full_text/query_string_query.rs
@@ -17,14 +17,9 @@ use crate::util::*;
 ///     .name("test");
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html>
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct QueryStringQuery {
-    #[serde(rename = "query_string")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
-struct Inner {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     query: Text,
 
@@ -105,31 +100,29 @@ impl Query {
         S: Into<Text>,
     {
         QueryStringQuery {
-            inner: Inner {
-                query: query.into(),
-                fields: vec![],
-                default_operator: None,
-                analyze_wildcard: None,
-                analyzer: None,
-                auto_generate_synonyms_phrase_query: None,
-                fuzzy_transpositions: None,
-                fuzzy_max_expansions: None,
-                fuzzy_prefix_length: None,
-                quote_field_suffix: None,
-                lenient: None,
-                minimum_should_match: None,
-                allow_leading_wildcard: None,
-                default_field: None,
-                enable_position_increments: None,
-                fuzziness: None,
-                max_determinized_states: None,
-                phrase_slop: None,
-                quote_analyzer: None,
-                rewrite: None,
-                time_zone: None,
-                boost: None,
-                _name: None,
-            },
+            query: query.into(),
+            fields: vec![],
+            default_operator: None,
+            analyze_wildcard: None,
+            analyzer: None,
+            auto_generate_synonyms_phrase_query: None,
+            fuzzy_transpositions: None,
+            fuzzy_max_expansions: None,
+            fuzzy_prefix_length: None,
+            quote_field_suffix: None,
+            lenient: None,
+            minimum_should_match: None,
+            allow_leading_wildcard: None,
+            default_field: None,
+            enable_position_increments: None,
+            fuzziness: None,
+            max_determinized_states: None,
+            phrase_slop: None,
+            quote_analyzer: None,
+            rewrite: None,
+            time_zone: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -159,7 +152,7 @@ impl QueryStringQuery {
     where
         S: ToString,
     {
-        self.inner.default_field = Some(default_field.to_string());
+        self.default_field = Some(default_field.to_string());
         self
     }
 
@@ -168,7 +161,7 @@ impl QueryStringQuery {
     ///
     /// Defaults to `true`.
     pub fn allow_leading_wildcard(mut self, allow_leading_wildcard: bool) -> Self {
-        self.inner.allow_leading_wildcard = Some(allow_leading_wildcard);
+        self.allow_leading_wildcard = Some(allow_leading_wildcard);
         self
     }
 
@@ -177,7 +170,7 @@ impl QueryStringQuery {
     ///
     /// Defaults to `false`.
     pub fn analyze_wildcard(mut self, analyze_wildcard: bool) -> Self {
-        self.inner.analyze_wildcard = Some(analyze_wildcard);
+        self.analyze_wildcard = Some(analyze_wildcard);
         self
     }
 
@@ -190,7 +183,7 @@ impl QueryStringQuery {
     where
         T: Into<String>,
     {
-        self.inner.analyzer = Some(analyzer.into());
+        self.analyzer = Some(analyzer.into());
         self
     }
 
@@ -205,14 +198,14 @@ impl QueryStringQuery {
         mut self,
         auto_generate_synonyms_phrase_query: bool,
     ) -> Self {
-        self.inner.auto_generate_synonyms_phrase_query = Some(auto_generate_synonyms_phrase_query);
+        self.auto_generate_synonyms_phrase_query = Some(auto_generate_synonyms_phrase_query);
         self
     }
 
     /// Default boolean logic used to interpret text in the query string if no
     /// operators are specified.
     pub fn default_operator(mut self, default_operator: Operator) -> Self {
-        self.inner.default_operator = Some(default_operator);
+        self.default_operator = Some(default_operator);
         self
     }
 
@@ -221,7 +214,7 @@ impl QueryStringQuery {
     ///
     /// Defaults to `true`.
     pub fn enable_position_increments(mut self, enable_position_increments: bool) -> Self {
-        self.inner.enable_position_increments = Some(enable_position_increments);
+        self.enable_position_increments = Some(enable_position_increments);
         self
     }
 
@@ -234,14 +227,14 @@ impl QueryStringQuery {
         I: IntoIterator,
         I::Item: ToString,
     {
-        self.inner.fields = fields.into_iter().map(|x| x.to_string()).collect();
+        self.fields = fields.into_iter().map(|x| x.to_string()).collect();
         self
     }
 
     /// Maximum edit distance allowed for fuzzy matching. For fuzzy syntax, see
     /// [`Fuzziness`].
     pub fn fuzziness(mut self, fuzziness: Fuzziness) -> Self {
-        self.inner.fuzziness = Some(fuzziness);
+        self.fuzziness = Some(fuzziness);
         self
     }
 
@@ -249,7 +242,7 @@ impl QueryStringQuery {
     ///
     /// Defaults to `50`.
     pub fn fuzzy_max_expansions(mut self, fuzzy_max_expansions: u32) -> Self {
-        self.inner.fuzzy_max_expansions = Some(fuzzy_max_expansions);
+        self.fuzzy_max_expansions = Some(fuzzy_max_expansions);
         self
     }
 
@@ -257,7 +250,7 @@ impl QueryStringQuery {
     ///
     /// Defaults to `0`.
     pub fn fuzzy_prefix_length(mut self, fuzzy_prefix_length: u32) -> Self {
-        self.inner.fuzzy_prefix_length = Some(fuzzy_prefix_length);
+        self.fuzzy_prefix_length = Some(fuzzy_prefix_length);
         self
     }
 
@@ -266,7 +259,7 @@ impl QueryStringQuery {
     ///
     /// Defaults to `true`.
     pub fn fuzzy_transpositions(mut self, fuzzy_transpositions: bool) -> Self {
-        self.inner.fuzzy_transpositions = Some(fuzzy_transpositions);
+        self.fuzzy_transpositions = Some(fuzzy_transpositions);
         self
     }
 
@@ -277,7 +270,7 @@ impl QueryStringQuery {
     ///
     /// Defaults to `false`.
     pub fn lenient(mut self, lenient: bool) -> Self {
-        self.inner.lenient = Some(lenient);
+        self.lenient = Some(lenient);
         self
     }
 
@@ -296,7 +289,7 @@ impl QueryStringQuery {
     /// unintentionally consuming too many resources. You may need to increase
     /// this limit to run complex regular expressions.
     pub fn max_determinized_states(mut self, max_determinized_states: u32) -> Self {
-        self.inner.max_determinized_states = Some(max_determinized_states);
+        self.max_determinized_states = Some(max_determinized_states);
         self
     }
 
@@ -308,7 +301,7 @@ impl QueryStringQuery {
     where
         T: Into<MinimumShouldMatch>,
     {
-        self.inner.minimum_should_match = Some(minimum_should_match.into());
+        self.minimum_should_match = Some(minimum_should_match.into());
         self
     }
 
@@ -325,7 +318,7 @@ impl QueryStringQuery {
     where
         S: ToString,
     {
-        self.inner.quote_analyzer = Some(quote_analyzer.to_string());
+        self.quote_analyzer = Some(quote_analyzer.to_string());
         self
     }
 
@@ -335,7 +328,7 @@ impl QueryStringQuery {
     /// Defaults to `0`. If `0`, exact phrase matches are required. Transposed
     /// terms have a slop of `2`.
     pub fn phrase_slop(mut self, phrase_slop: u32) -> Self {
-        self.inner.phrase_slop = Some(phrase_slop);
+        self.phrase_slop = Some(phrase_slop);
         self
     }
 
@@ -348,14 +341,14 @@ impl QueryStringQuery {
     where
         S: ToString,
     {
-        self.inner.quote_field_suffix = Some(quote_field_suffix.to_string());
+        self.quote_field_suffix = Some(quote_field_suffix.to_string());
         self
     }
 
     /// Method used to rewrite the query. For valid values and more
     /// information, see the [`rewrite` parameter](Rewrite).
     pub fn rewrite(mut self, rewrite: Rewrite) -> Self {
-        self.inner.rewrite = Some(rewrite);
+        self.rewrite = Some(rewrite);
         self
     }
 
@@ -369,7 +362,7 @@ impl QueryStringQuery {
     where
         S: ToString,
     {
-        self.inner.time_zone = Some(time_zone.to_string());
+        self.time_zone = Some(time_zone.to_string());
         self
     }
 
@@ -378,9 +371,11 @@ impl QueryStringQuery {
 
 impl ShouldSkip for QueryStringQuery {
     fn should_skip(&self) -> bool {
-        self.inner.query.should_skip()
+        self.query.should_skip()
     }
 }
+
+serialize_query!("query_string": QueryStringQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/simple_query_string_query.rs
+++ b/src/search/queries/full_text/simple_query_string_query.rs
@@ -17,14 +17,9 @@ use crate::util::*;
 ///     .name("test");
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html>
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct SimpleQueryStringQuery {
-    #[serde(rename = "simple_query_string")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
-struct Inner {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     query: Text,
 
@@ -84,23 +79,21 @@ impl Query {
         S: Into<Text>,
     {
         SimpleQueryStringQuery {
-            inner: Inner {
-                query: query.into(),
-                fields: vec![],
-                default_operator: None,
-                analyze_wildcard: None,
-                analyzer: None,
-                auto_generate_synonyms_phrase_query: None,
-                fuzzy_transpositions: None,
-                fuzzy_max_expansions: None,
-                flags: vec![],
-                fuzzy_prefix_length: None,
-                quote_field_suffix: None,
-                lenient: None,
-                minimum_should_match: None,
-                boost: None,
-                _name: None,
-            },
+            query: query.into(),
+            fields: vec![],
+            default_operator: None,
+            analyze_wildcard: None,
+            analyzer: None,
+            auto_generate_synonyms_phrase_query: None,
+            fuzzy_transpositions: None,
+            fuzzy_max_expansions: None,
+            flags: vec![],
+            fuzzy_prefix_length: None,
+            quote_field_suffix: None,
+            lenient: None,
+            minimum_should_match: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -123,14 +116,14 @@ impl SimpleQueryStringQuery {
         I: IntoIterator,
         I::Item: ToString,
     {
-        self.inner.fields = fields.into_iter().map(|x| x.to_string()).collect();
+        self.fields = fields.into_iter().map(|x| x.to_string()).collect();
         self
     }
 
     /// Default boolean logic used to interpret text in the query string if no
     /// operators are specified.
     pub fn default_operator(mut self, default_operator: Operator) -> Self {
-        self.inner.default_operator = Some(default_operator);
+        self.default_operator = Some(default_operator);
         self
     }
 
@@ -139,7 +132,7 @@ impl SimpleQueryStringQuery {
     ///
     /// Defaults to `false`.
     pub fn analyze_wildcard(mut self, analyze_wildcard: bool) -> Self {
-        self.inner.analyze_wildcard = Some(analyze_wildcard);
+        self.analyze_wildcard = Some(analyze_wildcard);
         self
     }
 
@@ -152,7 +145,7 @@ impl SimpleQueryStringQuery {
     where
         T: Into<String>,
     {
-        self.inner.analyzer = Some(analyzer.into());
+        self.analyzer = Some(analyzer.into());
         self
     }
 
@@ -167,7 +160,7 @@ impl SimpleQueryStringQuery {
         mut self,
         auto_generate_synonyms_phrase_query: bool,
     ) -> Self {
-        self.inner.auto_generate_synonyms_phrase_query = Some(auto_generate_synonyms_phrase_query);
+        self.auto_generate_synonyms_phrase_query = Some(auto_generate_synonyms_phrase_query);
         self
     }
 
@@ -179,7 +172,7 @@ impl SimpleQueryStringQuery {
     where
         I: IntoIterator<Item = SimpleQueryStringQueryFlags>,
     {
-        self.inner.flags.extend(flags.into_iter());
+        self.flags.extend(flags.into_iter());
         self
     }
 
@@ -187,7 +180,7 @@ impl SimpleQueryStringQuery {
     ///
     /// Defaults to `50`.
     pub fn fuzzy_max_expansions(mut self, fuzzy_max_expansions: u32) -> Self {
-        self.inner.fuzzy_max_expansions = Some(fuzzy_max_expansions);
+        self.fuzzy_max_expansions = Some(fuzzy_max_expansions);
         self
     }
 
@@ -195,7 +188,7 @@ impl SimpleQueryStringQuery {
     ///
     /// Defaults to `0`.
     pub fn fuzzy_prefix_length(mut self, fuzzy_prefix_length: u32) -> Self {
-        self.inner.fuzzy_prefix_length = Some(fuzzy_prefix_length);
+        self.fuzzy_prefix_length = Some(fuzzy_prefix_length);
         self
     }
 
@@ -204,7 +197,7 @@ impl SimpleQueryStringQuery {
     ///
     /// Defaults to `true`.
     pub fn fuzzy_transpositions(mut self, fuzzy_transpositions: bool) -> Self {
-        self.inner.fuzzy_transpositions = Some(fuzzy_transpositions);
+        self.fuzzy_transpositions = Some(fuzzy_transpositions);
         self
     }
 
@@ -215,7 +208,7 @@ impl SimpleQueryStringQuery {
     ///
     /// Defaults to `false`.
     pub fn lenient(mut self, lenient: bool) -> Self {
-        self.inner.lenient = Some(lenient);
+        self.lenient = Some(lenient);
         self
     }
 
@@ -227,7 +220,7 @@ impl SimpleQueryStringQuery {
     where
         T: Into<MinimumShouldMatch>,
     {
-        self.inner.minimum_should_match = Some(minimum_should_match.into());
+        self.minimum_should_match = Some(minimum_should_match.into());
         self
     }
 
@@ -240,7 +233,7 @@ impl SimpleQueryStringQuery {
     where
         S: ToString,
     {
-        self.inner.quote_field_suffix = Some(quote_field_suffix.to_string());
+        self.quote_field_suffix = Some(quote_field_suffix.to_string());
         self
     }
 
@@ -249,9 +242,11 @@ impl SimpleQueryStringQuery {
 
 impl ShouldSkip for SimpleQueryStringQuery {
     fn should_skip(&self) -> bool {
-        self.inner.query.should_skip()
+        self.query.should_skip()
     }
 }
+
+serialize_query!("simple_query_string": SimpleQueryStringQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/geo/geo_bounding_box_query.rs
+++ b/src/search/queries/geo/geo_bounding_box_query.rs
@@ -8,23 +8,20 @@ use serde::Serialize;
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct GeoBoundingBoxQuery {
-    #[serde(rename = "geo_bounding_box")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(flatten)]
     pair: KeyValuePair<String, GeoBoundingBox>,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     validation_method: Option<ValidationMethod>,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     boost: Option<Boost>,
+
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     _name: Option<String>,
 }
-
 impl Query {
     /// Creates an instance of [`GeoBoundingBoxQuery`]
     ///
@@ -36,12 +33,10 @@ impl Query {
         U: Into<GeoBoundingBox>,
     {
         GeoBoundingBoxQuery {
-            inner: Inner {
-                pair: KeyValuePair::new(field.into(), value.into()),
-                validation_method: None,
-                boost: None,
-                _name: None,
-            },
+            pair: KeyValuePair::new(field.into(), value.into()),
+            validation_method: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -50,7 +45,7 @@ impl GeoBoundingBoxQuery {
     /// Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude, set to
     /// `COERCE` to also try to infer correct latitude or longitude. (default is `STRICT`).
     pub fn validation_method(mut self, validation_method: ValidationMethod) -> Self {
-        self.inner.validation_method = Some(validation_method);
+        self.validation_method = Some(validation_method);
         self
     }
 
@@ -59,9 +54,11 @@ impl GeoBoundingBoxQuery {
 
 impl ShouldSkip for GeoBoundingBoxQuery {
     fn should_skip(&self) -> bool {
-        self.inner.pair.key.should_skip()
+        self.pair.key.should_skip()
     }
 }
+
+serialize_query!("geo_bounding_box": GeoBoundingBoxQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/geo/geo_distance_query.rs
+++ b/src/search/queries/geo/geo_distance_query.rs
@@ -8,13 +8,8 @@ use serde::Serialize;
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct GeoDistanceQuery {
-    #[serde(rename = "geo_distance")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(flatten)]
     pair: KeyValuePair<String, GeoPoint>,
 
@@ -46,14 +41,12 @@ impl Query {
         V: Into<Distance>,
     {
         GeoDistanceQuery {
-            inner: Inner {
-                pair: KeyValuePair::new(field.into(), origin.into()),
-                distance: distance.into(),
-                distance_type: None,
-                validation_method: None,
-                boost: None,
-                _name: None,
-            },
+            pair: KeyValuePair::new(field.into(), origin.into()),
+            distance: distance.into(),
+            distance_type: None,
+            validation_method: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -62,14 +55,14 @@ impl GeoDistanceQuery {
     /// Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude, set to
     /// `COERCE` to also try to infer correct latitude or longitude. (default is `STRICT`).
     pub fn validation_method(mut self, validation_method: ValidationMethod) -> Self {
-        self.inner.validation_method = Some(validation_method);
+        self.validation_method = Some(validation_method);
         self
     }
 
     /// How to compute the distance. Can either be `Arc` (default),
     /// or `Plane` (faster, but inaccurate on long distances and close to the poles).
     pub fn distance_type(mut self, distance_type: DistanceType) -> Self {
-        self.inner.distance_type = Some(distance_type);
+        self.distance_type = Some(distance_type);
         self
     }
 
@@ -78,9 +71,11 @@ impl GeoDistanceQuery {
 
 impl ShouldSkip for GeoDistanceQuery {
     fn should_skip(&self) -> bool {
-        self.inner.pair.key.should_skip()
+        self.pair.key.should_skip()
     }
 }
+
+serialize_query!("geo_distance": GeoDistanceQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/geo/geo_shape_lookup_query.rs
+++ b/src/search/queries/geo/geo_shape_lookup_query.rs
@@ -16,13 +16,8 @@ use serde::Serialize;
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct GeoShapeLookupQuery {
-    #[serde(rename = "geo_shape")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(flatten)]
     pair: KeyValuePair<String, Shape>,
 
@@ -69,23 +64,21 @@ impl Query {
         T: ToString,
     {
         GeoShapeLookupQuery {
-            inner: Inner {
-                pair: KeyValuePair::new(
-                    field.to_string(),
-                    Shape {
-                        indexed_shape: IndexedShape {
-                            id: id.to_string(),
-                            index: None,
-                            path: None,
-                            routing: None,
-                        },
-                        relation: None,
+            pair: KeyValuePair::new(
+                field.to_string(),
+                Shape {
+                    indexed_shape: IndexedShape {
+                        id: id.to_string(),
+                        index: None,
+                        path: None,
+                        routing: None,
                     },
-                ),
-                ignore_unmapped: None,
-                boost: None,
-                _name: None,
-            },
+                    relation: None,
+                },
+            ),
+            ignore_unmapped: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -96,7 +89,7 @@ impl GeoShapeLookupQuery {
     where
         S: ToString,
     {
-        self.inner.pair.value.indexed_shape.index = Some(index.to_string());
+        self.pair.value.indexed_shape.index = Some(index.to_string());
         self
     }
 
@@ -105,7 +98,7 @@ impl GeoShapeLookupQuery {
     where
         S: ToString,
     {
-        self.inner.pair.value.indexed_shape.path = Some(path.to_string());
+        self.pair.value.indexed_shape.path = Some(path.to_string());
         self
     }
 
@@ -114,7 +107,7 @@ impl GeoShapeLookupQuery {
     where
         S: ToString,
     {
-        self.inner.pair.value.indexed_shape.routing = Some(routing.to_string());
+        self.pair.value.indexed_shape.routing = Some(routing.to_string());
         self
     }
 
@@ -122,7 +115,7 @@ impl GeoShapeLookupQuery {
     /// mapping parameter determines which spatial relation operators may be
     /// used at search time.
     pub fn relation(mut self, relation: SpatialRelation) -> Self {
-        self.inner.pair.value.relation = Some(relation);
+        self.pair.value.relation = Some(relation);
         self
     }
 
@@ -132,7 +125,7 @@ impl GeoShapeLookupQuery {
     /// mappings. When set to `false` (the default value) the query will throw
     /// an exception if the field is not mapped.
     pub fn ignore_unmapped(mut self, ignore_unmapped: bool) -> Self {
-        self.inner.ignore_unmapped = Some(ignore_unmapped);
+        self.ignore_unmapped = Some(ignore_unmapped);
         self
     }
 
@@ -140,6 +133,8 @@ impl GeoShapeLookupQuery {
 }
 
 impl ShouldSkip for GeoShapeLookupQuery {}
+
+serialize_query!("geo_shape": GeoShapeLookupQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/geo/geo_shape_query.rs
+++ b/src/search/queries/geo/geo_shape_query.rs
@@ -16,13 +16,8 @@ use serde::Serialize;
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct GeoShapeQuery {
-    #[serde(rename = "geo_shape")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(flatten)]
     pair: KeyValuePair<String, InlineShape>,
 
@@ -55,18 +50,16 @@ impl Query {
         T: Into<GeoShape>,
     {
         GeoShapeQuery {
-            inner: Inner {
-                pair: KeyValuePair::new(
-                    field.to_string(),
-                    InlineShape {
-                        shape: shape.into(),
-                        relation: None,
-                    },
-                ),
-                ignore_unmapped: None,
-                boost: None,
-                _name: None,
-            },
+            pair: KeyValuePair::new(
+                field.to_string(),
+                InlineShape {
+                    shape: shape.into(),
+                    relation: None,
+                },
+            ),
+            ignore_unmapped: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -76,7 +69,7 @@ impl GeoShapeQuery {
     /// mapping parameter determines which spatial relation operators may be
     /// used at search time.
     pub fn relation(mut self, relation: SpatialRelation) -> Self {
-        self.inner.pair.value.relation = Some(relation);
+        self.pair.value.relation = Some(relation);
         self
     }
 
@@ -86,7 +79,7 @@ impl GeoShapeQuery {
     /// mappings. When set to `false` (the default value) the query will throw
     /// an exception if the field is not mapped.
     pub fn ignore_unmapped(mut self, ignore_unmapped: bool) -> Self {
-        self.inner.ignore_unmapped = Some(ignore_unmapped);
+        self.ignore_unmapped = Some(ignore_unmapped);
         self
     }
 
@@ -94,6 +87,8 @@ impl GeoShapeQuery {
 }
 
 impl ShouldSkip for GeoShapeQuery {}
+
+serialize_query!("geo_shape": GeoShapeQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/joining/has_child_query.rs
+++ b/src/search/queries/joining/has_child_query.rs
@@ -13,13 +13,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-HasChild-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct HasChildQuery {
-    #[serde(rename = "has_child")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     r#type: String,
 
     query: Box<Query>,
@@ -55,16 +50,14 @@ impl Query {
         U: Into<Query>,
     {
         HasChildQuery {
-            inner: Inner {
-                r#type: r#type.into(),
-                query: Box::new(query.into()),
-                ignore_unmapped: None,
-                max_children: None,
-                min_children: None,
-                score_mode: None,
-                boost: None,
-                _name: None,
-            },
+            r#type: r#type.into(),
+            query: Box::new(query.into()),
+            ignore_unmapped: None,
+            max_children: None,
+            min_children: None,
+            score_mode: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -77,14 +70,14 @@ impl HasChildQuery {
     ///
     /// You can use this parameter to query multiple indices that may not contain the `type`.
     pub fn ignore_unmapped(mut self, ignore_unmapped: bool) -> Self {
-        self.inner.ignore_unmapped = Some(ignore_unmapped);
+        self.ignore_unmapped = Some(ignore_unmapped);
         self
     }
 
     /// Maximum number of child documents that match the `query` allowed for a returned parent
     /// document. If the parent document exceeds this limit, it is excluded from the search results.
     pub fn max_children(mut self, max_children: u32) -> Self {
-        self.inner.max_children = Some(max_children);
+        self.max_children = Some(max_children);
         self
     }
 
@@ -92,14 +85,14 @@ impl HasChildQuery {
     /// returned parent document. If the parent document does not meet this limit, it is excluded
     /// from the search results.
     pub fn min_children(mut self, min_children: u32) -> Self {
-        self.inner.min_children = Some(min_children);
+        self.min_children = Some(min_children);
         self
     }
 
     /// Indicates how scores for matching child documents affect the root parent document’s
     /// relevance score.
     pub fn score_mode(mut self, score_mode: HasChildScoreMode) -> Self {
-        self.inner.score_mode = Some(score_mode);
+        self.score_mode = Some(score_mode);
         self
     }
 
@@ -108,9 +101,11 @@ impl HasChildQuery {
 
 impl ShouldSkip for HasChildQuery {
     fn should_skip(&self) -> bool {
-        self.inner.r#type.should_skip() || self.inner.query.should_skip()
+        self.r#type.should_skip() || self.query.should_skip()
     }
 }
+
+serialize_query!("has_child": HasChildQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/joining/has_parent_query.rs
+++ b/src/search/queries/joining/has_parent_query.rs
@@ -13,13 +13,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-HasParent-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct HasParentQuery {
-    #[serde(rename = "has_parent")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     parent_type: String,
 
     query: Box<Query>,
@@ -49,14 +44,12 @@ impl Query {
         U: Into<Query>,
     {
         HasParentQuery {
-            inner: Inner {
-                parent_type: parent_type.into(),
-                query: Box::new(query.into()),
-                score: None,
-                ignore_unmapped: None,
-                boost: None,
-                _name: None,
-            },
+            parent_type: parent_type.into(),
+            query: Box::new(query.into()),
+            score: None,
+            ignore_unmapped: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -72,7 +65,7 @@ impl HasParentQuery {
     /// If `true`, the relevance score of the matching parent document is aggregated into its child
     /// documents' relevance scores.
     pub fn score(mut self, score: bool) -> Self {
-        self.inner.score = Some(score);
+        self.score = Some(score);
         self
     }
 
@@ -83,7 +76,7 @@ impl HasParentQuery {
     ///
     /// You can use this parameter to query multiple indices that may not contain the `parent_type`.
     pub fn ignore_unmapped(mut self, ignore_unmapped: bool) -> Self {
-        self.inner.ignore_unmapped = Some(ignore_unmapped);
+        self.ignore_unmapped = Some(ignore_unmapped);
         self
     }
 
@@ -92,9 +85,11 @@ impl HasParentQuery {
 
 impl ShouldSkip for HasParentQuery {
     fn should_skip(&self) -> bool {
-        self.inner.parent_type.should_skip() || self.inner.query.should_skip()
+        self.parent_type.should_skip() || self.query.should_skip()
     }
 }
+
+serialize_query!("has_parent": HasParentQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/joining/nested_query.rs
+++ b/src/search/queries/joining/nested_query.rs
@@ -29,13 +29,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct NestedQuery {
-    #[serde(rename = "nested")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     path: String,
 
     query: Box<Query>,
@@ -75,15 +70,13 @@ impl Query {
         U: Into<Query>,
     {
         NestedQuery {
-            inner: Inner {
-                path: path.into(),
-                query: Box::new(query.into()),
-                score_mode: None,
-                ignore_unmapped: None,
-                inner_hits: None,
-                boost: None,
-                _name: None,
-            },
+            path: path.into(),
+            query: Box::new(query.into()),
+            score_mode: None,
+            ignore_unmapped: None,
+            inner_hits: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -93,7 +86,7 @@ impl NestedQuery {
     /// document’s
     /// [relevance score](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores).
     pub fn score_mode(mut self, score_mode: NestedQueryScoreMode) -> Self {
-        self.inner.score_mode = Some(score_mode);
+        self.score_mode = Some(score_mode);
         self
     }
 
@@ -106,7 +99,7 @@ impl NestedQuery {
     /// You can use this parameter to query multiple indices that may not
     /// contain the field `path`.
     pub fn ignore_unmapped(mut self, ignore_unmapped: bool) -> Self {
-        self.inner.ignore_unmapped = Some(ignore_unmapped);
+        self.ignore_unmapped = Some(ignore_unmapped);
         self
     }
 
@@ -129,7 +122,7 @@ impl NestedQuery {
     ///
     /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/inner-hits.html>
     pub fn inner_hits(mut self, inner_hits: InnerHits) -> Self {
-        self.inner.inner_hits = Some(Box::new(inner_hits));
+        self.inner_hits = Some(Box::new(inner_hits));
         self
     }
 
@@ -138,9 +131,11 @@ impl NestedQuery {
 
 impl ShouldSkip for NestedQuery {
     fn should_skip(&self) -> bool {
-        self.inner.query.should_skip()
+        self.query.should_skip()
     }
 }
+
+serialize_query!("nested": NestedQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/joining/parent_id_query.rs
+++ b/src/search/queries/joining/parent_id_query.rs
@@ -13,13 +13,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ParentId-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct ParentIdQuery {
-    #[serde(rename = "parent_id")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     r#type: String,
 
     id: String,
@@ -46,13 +41,11 @@ impl Query {
         U: ToString,
     {
         ParentIdQuery {
-            inner: Inner {
-                r#type: r#type.to_string(),
-                id: id.to_string(),
-                ignore_unmapped: None,
-                boost: None,
-                _name: None,
-            },
+            r#type: r#type.to_string(),
+            id: id.to_string(),
+            ignore_unmapped: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -65,7 +58,7 @@ impl ParentIdQuery {
     ///
     /// You can use this parameter to query multiple indices that may not contain the `type`.
     pub fn ignore_unmapped(mut self, ignore_unmapped: bool) -> Self {
-        self.inner.ignore_unmapped = Some(ignore_unmapped);
+        self.ignore_unmapped = Some(ignore_unmapped);
         self
     }
 
@@ -74,9 +67,11 @@ impl ParentIdQuery {
 
 impl ShouldSkip for ParentIdQuery {
     fn should_skip(&self) -> bool {
-        self.inner.r#type.should_skip() || self.inner.id.should_skip()
+        self.r#type.should_skip() || self.id.should_skip()
     }
 }
+
+serialize_query!("parent_id": ParentIdQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/match_all_query.rs
+++ b/src/search/queries/match_all_query.rs
@@ -16,19 +16,16 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[serde(remote = "Self")]
 pub struct MatchAllQuery {
-    #[serde(rename = "match_all")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
-struct Inner {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     boost: Option<Boost>,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     _name: Option<String>,
 }
+
+serialize_query!("match_all": MatchAllQuery);
 
 impl Query {
     /// Creates an instance of [`MatchAllQuery`]

--- a/src/search/queries/match_none_query.rs
+++ b/src/search/queries/match_none_query.rs
@@ -16,13 +16,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[serde(remote = "Self")]
 pub struct MatchNoneQuery {
-    #[serde(rename = "match_none")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
-struct Inner {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     boost: Option<Boost>,
 
@@ -40,6 +35,8 @@ impl Query {
 impl MatchNoneQuery {
     add_boost_and_name!();
 }
+
+serialize_query!("match_none": MatchNoneQuery);
 
 impl ShouldSkip for MatchNoneQuery {}
 

--- a/src/search/queries/shape/shape_lookup_query.rs
+++ b/src/search/queries/shape/shape_lookup_query.rs
@@ -8,13 +8,8 @@ use serde::Serialize;
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-shape-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct ShapeLookupQuery {
-    #[serde(rename = "shape")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(flatten)]
     pair: KeyValuePair<String, Shape>,
 
@@ -61,23 +56,21 @@ impl Query {
         T: ToString,
     {
         ShapeLookupQuery {
-            inner: Inner {
-                pair: KeyValuePair::new(
-                    field.to_string(),
-                    Shape {
-                        indexed_shape: IndexedShape {
-                            id: id.to_string(),
-                            index: None,
-                            path: None,
-                            routing: None,
-                        },
-                        relation: None,
+            pair: KeyValuePair::new(
+                field.to_string(),
+                Shape {
+                    indexed_shape: IndexedShape {
+                        id: id.to_string(),
+                        index: None,
+                        path: None,
+                        routing: None,
                     },
-                ),
-                ignore_unmapped: None,
-                boost: None,
-                _name: None,
-            },
+                    relation: None,
+                },
+            ),
+            ignore_unmapped: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -88,7 +81,7 @@ impl ShapeLookupQuery {
     where
         S: ToString,
     {
-        self.inner.pair.value.indexed_shape.index = Some(index.to_string());
+        self.pair.value.indexed_shape.index = Some(index.to_string());
         self
     }
 
@@ -97,7 +90,7 @@ impl ShapeLookupQuery {
     where
         S: ToString,
     {
-        self.inner.pair.value.indexed_shape.path = Some(path.to_string());
+        self.pair.value.indexed_shape.path = Some(path.to_string());
         self
     }
 
@@ -106,7 +99,7 @@ impl ShapeLookupQuery {
     where
         S: ToString,
     {
-        self.inner.pair.value.indexed_shape.routing = Some(routing.to_string());
+        self.pair.value.indexed_shape.routing = Some(routing.to_string());
         self
     }
 
@@ -114,7 +107,7 @@ impl ShapeLookupQuery {
     /// mapping parameter determines which spatial relation operators may be
     /// used at search time.
     pub fn relation(mut self, relation: SpatialRelation) -> Self {
-        self.inner.pair.value.relation = Some(relation);
+        self.pair.value.relation = Some(relation);
         self
     }
 
@@ -124,7 +117,7 @@ impl ShapeLookupQuery {
     /// mappings. When set to `false` (the default value) the query will throw
     /// an exception if the field is not mapped.
     pub fn ignore_unmapped(mut self, ignore_unmapped: bool) -> Self {
-        self.inner.ignore_unmapped = Some(ignore_unmapped);
+        self.ignore_unmapped = Some(ignore_unmapped);
         self
     }
 
@@ -132,6 +125,8 @@ impl ShapeLookupQuery {
 }
 
 impl ShouldSkip for ShapeLookupQuery {}
+
+serialize_query!("shape": ShapeLookupQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/shape/shape_query.rs
+++ b/src/search/queries/shape/shape_query.rs
@@ -8,13 +8,8 @@ use serde::Serialize;
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-shape-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct ShapeQuery {
-    #[serde(rename = "shape")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(flatten)]
     pair: KeyValuePair<String, InlineShape>,
 
@@ -47,18 +42,16 @@ impl Query {
         T: Into<Shape>,
     {
         ShapeQuery {
-            inner: Inner {
-                pair: KeyValuePair::new(
-                    field.to_string(),
-                    InlineShape {
-                        shape: shape.into(),
-                        relation: None,
-                    },
-                ),
-                ignore_unmapped: None,
-                boost: None,
-                _name: None,
-            },
+            pair: KeyValuePair::new(
+                field.to_string(),
+                InlineShape {
+                    shape: shape.into(),
+                    relation: None,
+                },
+            ),
+            ignore_unmapped: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -68,7 +61,7 @@ impl ShapeQuery {
     /// mapping parameter determines which spatial relation operators may be
     /// used at search time.
     pub fn relation(mut self, relation: SpatialRelation) -> Self {
-        self.inner.pair.value.relation = Some(relation);
+        self.pair.value.relation = Some(relation);
         self
     }
 
@@ -78,7 +71,7 @@ impl ShapeQuery {
     /// mappings. When set to `false` (the default value) the query will throw
     /// an exception if the field is not mapped.
     pub fn ignore_unmapped(mut self, ignore_unmapped: bool) -> Self {
-        self.inner.ignore_unmapped = Some(ignore_unmapped);
+        self.ignore_unmapped = Some(ignore_unmapped);
         self
     }
 
@@ -86,6 +79,8 @@ impl ShapeQuery {
 }
 
 impl ShouldSkip for ShapeQuery {}
+
+serialize_query!("shape": ShapeQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/distance_feature_query.rs
+++ b/src/search/queries/specialized/distance_feature_query.rs
@@ -91,16 +91,8 @@ impl Origin for GeoPoint {
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-distance-feature-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct DistanceFeatureQuery<O>
-where
-    O: Origin,
-{
-    #[serde(rename = "distance_feature")]
-    inner: Inner<O>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner<O>
 where
     O: Origin,
 {
@@ -161,13 +153,11 @@ impl Query {
         O: Origin,
     {
         DistanceFeatureQuery {
-            inner: Inner {
-                field: field.into(),
-                origin,
-                pivot,
-                boost: None,
-                _name: None,
-            },
+            field: field.into(),
+            origin,
+            pivot,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -180,6 +170,9 @@ where
 }
 
 impl<O> ShouldSkip for DistanceFeatureQuery<O> where O: Origin {}
+
+serialize_query!("distance_feature": DistanceFeatureQuery<DateTime<Utc>>);
+serialize_query!("distance_feature": DistanceFeatureQuery<GeoPoint>);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/more_like_this_query.rs
+++ b/src/search/queries/specialized/more_like_this_query.rs
@@ -50,13 +50,8 @@ use std::collections::BTreeSet;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-mlt-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct MoreLikeThisQuery {
-    #[serde(rename = "more_like_this")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     fields: Option<Vec<String>>,
 
@@ -220,25 +215,23 @@ impl Query {
         I::Item: Into<Like>,
     {
         MoreLikeThisQuery {
-            inner: Inner {
-                like: like.into_iter().map(Into::into).collect(),
-                fields: None,
-                unlike: None,
-                min_term_freq: None,
-                max_query_terms: None,
-                min_doc_freq: None,
-                max_doc_freq: None,
-                min_word_length: None,
-                max_word_length: None,
-                stop_words: None,
-                analyzer: None,
-                minimum_should_match: None,
-                fail_on_unsupported_field: None,
-                boost_terms: None,
-                include: None,
-                boost: None,
-                _name: None,
-            },
+            like: like.into_iter().map(Into::into).collect(),
+            fields: None,
+            unlike: None,
+            min_term_freq: None,
+            max_query_terms: None,
+            min_doc_freq: None,
+            max_doc_freq: None,
+            min_word_length: None,
+            max_word_length: None,
+            stop_words: None,
+            analyzer: None,
+            minimum_should_match: None,
+            fail_on_unsupported_field: None,
+            boost_terms: None,
+            include: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -252,7 +245,7 @@ impl MoreLikeThisQuery {
         I: IntoIterator,
         I::Item: Into<String>,
     {
-        self.inner.fields = Some(fields.into_iter().map(Into::into).collect());
+        self.fields = Some(fields.into_iter().map(Into::into).collect());
         self
     }
 
@@ -263,7 +256,7 @@ impl MoreLikeThisQuery {
         I: IntoIterator,
         I::Item: Into<Like>,
     {
-        self.inner.unlike = Some(unlike.into_iter().map(Into::into).collect());
+        self.unlike = Some(unlike.into_iter().map(Into::into).collect());
         self
     }
 
@@ -271,21 +264,21 @@ impl MoreLikeThisQuery {
     /// Increasing this value gives greater accuracy at the expense of query execution speed.
     /// Defaults to 25.
     pub fn max_query_terms(mut self, max_query_terms: i64) -> Self {
-        self.inner.max_query_terms = Some(max_query_terms);
+        self.max_query_terms = Some(max_query_terms);
         self
     }
 
     /// The minimum term frequency below which the terms will be ignored from the input document.
     /// Defaults to 2.
     pub fn min_term_freq(mut self, min_term_freq: i64) -> Self {
-        self.inner.min_term_freq = Some(min_term_freq);
+        self.min_term_freq = Some(min_term_freq);
         self
     }
 
     /// The minimum document frequency below which the terms will be ignored from the input document.
     /// Defaults to 5.
     pub fn min_doc_freq(mut self, min_doc_freq: i64) -> Self {
-        self.inner.min_doc_freq = Some(min_doc_freq);
+        self.min_doc_freq = Some(min_doc_freq);
         self
     }
 
@@ -293,19 +286,19 @@ impl MoreLikeThisQuery {
     /// This could be useful in order to ignore highly frequent words such as stop words.
     /// Defaults to unbounded (Integer.MAX_VALUE, which is 2^31-1 or 2147483647).
     pub fn max_doc_freq(mut self, max_doc_freq: i64) -> Self {
-        self.inner.max_doc_freq = Some(max_doc_freq);
+        self.max_doc_freq = Some(max_doc_freq);
         self
     }
 
     /// The minimum word length below which the terms will be ignored. Defaults to 0.
     pub fn min_word_length(mut self, min_word_length: i64) -> Self {
-        self.inner.min_word_length = Some(min_word_length);
+        self.min_word_length = Some(min_word_length);
         self
     }
 
     /// The maximum word length above which the terms will be ignored. Defaults to unbounded (0).
     pub fn max_word_length(mut self, max_word_length: i64) -> Self {
-        self.inner.max_word_length = Some(max_word_length);
+        self.max_word_length = Some(max_word_length);
         self
     }
 
@@ -317,7 +310,7 @@ impl MoreLikeThisQuery {
         T: IntoIterator,
         T::Item: Into<String>,
     {
-        self.inner.stop_words = Some(stop_words.into_iter().map(Into::into).collect());
+        self.stop_words = Some(stop_words.into_iter().map(Into::into).collect());
         self
     }
 
@@ -327,7 +320,7 @@ impl MoreLikeThisQuery {
     where
         T: Into<String>,
     {
-        self.inner.analyzer = Some(analyzer.into());
+        self.analyzer = Some(analyzer.into());
         self
     }
 
@@ -337,14 +330,14 @@ impl MoreLikeThisQuery {
     where
         T: Into<String>,
     {
-        self.inner.minimum_should_match = Some(minimum_should_match.into());
+        self.minimum_should_match = Some(minimum_should_match.into());
         self
     }
 
     /// Controls whether the query should fail (throw an exception) if any of the specified fields are not of the supported types (text or keyword).
     /// Set this to false to ignore the field and continue processing. Defaults to true.
     pub fn fail_on_unsupported_field(mut self, fail_on_unsupported_field: bool) -> Self {
-        self.inner.fail_on_unsupported_field = Some(fail_on_unsupported_field);
+        self.fail_on_unsupported_field = Some(fail_on_unsupported_field);
         self
     }
 
@@ -354,13 +347,13 @@ impl MoreLikeThisQuery {
     where
         T: Into<f64>,
     {
-        self.inner.boost_terms = Some(boost_terms.into());
+        self.boost_terms = Some(boost_terms.into());
         self
     }
 
     /// Specifies whether the input documents should also be included in the search results returned. Defaults to `false`.
     pub fn include(mut self, include: bool) -> Self {
-        self.inner.include = Some(include);
+        self.include = Some(include);
         self
     }
 
@@ -369,9 +362,11 @@ impl MoreLikeThisQuery {
 
 impl ShouldSkip for MoreLikeThisQuery {
     fn should_skip(&self) -> bool {
-        self.inner.like.is_empty()
+        self.like.is_empty()
     }
 }
+
+serialize_query!("more_like_this": MoreLikeThisQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/percolate_lookup_query.rs
+++ b/src/search/queries/specialized/percolate_lookup_query.rs
@@ -16,13 +16,8 @@ use std::convert::TryInto;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-percolate-query.html#_percolating_an_existing_document>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct PercolateLookupQuery {
-    #[serde(rename = "percolate")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     field: String,
 
     index: String,
@@ -55,15 +50,13 @@ impl Query {
         U: ToString,
     {
         PercolateLookupQuery {
-            inner: Inner {
-                field: field.to_string(),
-                index: index.to_string(),
-                id: id.to_string(),
-                routing: None,
-                preference: None,
-                version: None,
-                name: None,
-            },
+            field: field.to_string(),
+            index: index.to_string(),
+            id: id.to_string(),
+            routing: None,
+            preference: None,
+            version: None,
+            name: None,
         }
     }
 }
@@ -74,7 +67,7 @@ impl PercolateLookupQuery {
     where
         S: ToString,
     {
-        self.inner.routing = Some(routing.to_string());
+        self.routing = Some(routing.to_string());
         self
     }
 
@@ -83,7 +76,7 @@ impl PercolateLookupQuery {
     where
         S: ToString,
     {
-        self.inner.preference = Some(preference.to_string());
+        self.preference = Some(preference.to_string());
         self
     }
 
@@ -93,7 +86,7 @@ impl PercolateLookupQuery {
         S: TryInto<u64>,
     {
         if let Ok(version) = version.try_into() {
-            self.inner.version = Some(version);
+            self.version = Some(version);
         }
         self
     }
@@ -104,12 +97,14 @@ impl PercolateLookupQuery {
     where
         S: ToString,
     {
-        self.inner.name = Some(name.to_string());
+        self.name = Some(name.to_string());
         self
     }
 }
 
 impl ShouldSkip for PercolateLookupQuery {}
+
+serialize_query!("percolate": PercolateLookupQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/percolate_query.rs
+++ b/src/search/queries/specialized/percolate_query.rs
@@ -23,13 +23,8 @@ use serde::Serialize;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-percolate-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct PercolateQuery {
-    #[serde(rename = "percolate")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     field: String,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
@@ -57,11 +52,9 @@ impl Query {
         };
 
         PercolateQuery {
-            inner: Inner {
-                field: field.to_string(),
-                source,
-                name: None,
-            },
+            field: field.to_string(),
+            source,
+            name: None,
         }
     }
 }
@@ -73,16 +66,18 @@ impl PercolateQuery {
     where
         S: ToString,
     {
-        self.inner.name = Some(name.to_string());
+        self.name = Some(name.to_string());
         self
     }
 }
 
 impl ShouldSkip for PercolateQuery {
     fn should_skip(&self) -> bool {
-        self.inner.source.should_skip()
+        self.source.should_skip()
     }
 }
+
+serialize_query!("percolate": PercolateQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/pinned_query.rs
+++ b/src/search/queries/specialized/pinned_query.rs
@@ -15,13 +15,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct PinnedQuery {
-    #[serde(rename = "pinned")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(flatten)]
     values: PinnedQueryValues,
 
@@ -43,12 +38,10 @@ impl Query {
         Q: Into<Query>,
     {
         PinnedQuery {
-            inner: Inner {
-                values,
-                organic: Box::new(organic.into()),
-                boost: None,
-                _name: None,
-            },
+            values,
+            organic: Box::new(organic.into()),
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -59,9 +52,11 @@ impl PinnedQuery {
 
 impl ShouldSkip for PinnedQuery {
     fn should_skip(&self) -> bool {
-        self.inner.organic.should_skip()
+        self.organic.should_skip()
     }
 }
+
+serialize_query!("pinned": PinnedQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/rank_feature_query.rs
+++ b/src/search/queries/specialized/rank_feature_query.rs
@@ -29,9 +29,15 @@ use serde::Serialize;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-rank-feature-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct RankFeatureQuery {
-    #[serde(rename = "rank_feature")]
-    inner: Inner,
+    field: String,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    boost: Option<Boost>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    _name: Option<String>,
 }
 
 /// Boosts the relevance score of documents based on the numeric value of a `rank_feature` or
@@ -61,9 +67,17 @@ pub struct RankFeatureQuery {
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-rank-feature-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct RankFeatureSaturationQuery {
-    #[serde(rename = "rank_feature")]
-    inner: InnerSaturation,
+    field: String,
+
+    saturation: Saturation,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    boost: Option<Boost>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    _name: Option<String>,
 }
 
 /// Boosts the relevance score of documents based on the numeric value of a `rank_feature` or
@@ -93,9 +107,17 @@ pub struct RankFeatureSaturationQuery {
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-rank-feature-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct RankFeatureLogarithmQuery {
-    #[serde(rename = "rank_feature")]
-    inner: InnerLogarithm,
+    field: String,
+
+    log: Logarithm,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    boost: Option<Boost>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    _name: Option<String>,
 }
 
 /// Boosts the relevance score of documents based on the numeric value of a `rank_feature` or
@@ -125,9 +147,17 @@ pub struct RankFeatureLogarithmQuery {
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-rank-feature-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct RankFeatureSigmoidQuery {
-    #[serde(rename = "rank_feature")]
-    inner: InnerSigmoid,
+    field: String,
+
+    sigmoid: Sigmoid,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    boost: Option<Boost>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    _name: Option<String>,
 }
 
 /// Boosts the relevance score of documents based on the numeric value of a `rank_feature` or
@@ -157,9 +187,17 @@ pub struct RankFeatureSigmoidQuery {
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-rank-feature-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct RankFeatureLinearQuery {
-    #[serde(rename = "rank_feature")]
-    inner: InnerLinear,
+    field: String,
+
+    linear: Linear,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    boost: Option<Boost>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    _name: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -182,69 +220,6 @@ struct Sigmoid {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 struct Linear {}
 
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
-    field: String,
-
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    boost: Option<Boost>,
-
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    _name: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct InnerSaturation {
-    field: String,
-
-    saturation: Saturation,
-
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    boost: Option<Boost>,
-
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    _name: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct InnerLogarithm {
-    field: String,
-
-    log: Logarithm,
-
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    boost: Option<Boost>,
-
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    _name: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct InnerSigmoid {
-    field: String,
-
-    sigmoid: Sigmoid,
-
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    boost: Option<Boost>,
-
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    _name: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct InnerLinear {
-    field: String,
-
-    linear: Linear,
-
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    boost: Option<Boost>,
-
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    _name: Option<String>,
-}
-
 impl Query {
     /// Creates an instance of [`RankFeatureQuery`]
     ///
@@ -254,11 +229,9 @@ impl Query {
         T: Into<String>,
     {
         RankFeatureQuery {
-            inner: Inner {
-                field: field.into(),
-                boost: None,
-                _name: None,
-            },
+            field: field.into(),
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -277,12 +250,10 @@ impl RankFeatureQuery {
     /// default value if you haven’t had the opportunity to train a good pivot value.
     pub fn saturation(self) -> RankFeatureSaturationQuery {
         RankFeatureSaturationQuery {
-            inner: InnerSaturation {
-                field: self.inner.field,
-                boost: self.inner.boost,
-                _name: self.inner._name,
-                saturation: Saturation { pivot: None },
-            },
+            field: self.field,
+            boost: self.boost,
+            _name: self._name,
+            saturation: Saturation { pivot: None },
         }
     }
 
@@ -293,12 +264,10 @@ impl RankFeatureQuery {
     /// This function only supports rank features that have a positive score impact.
     pub fn logarithm(self, scaling_factor: f64) -> RankFeatureLogarithmQuery {
         RankFeatureLogarithmQuery {
-            inner: InnerLogarithm {
-                field: self.inner.field,
-                boost: self.inner.boost,
-                _name: self.inner._name,
-                log: Logarithm { scaling_factor },
-            },
+            field: self.field,
+            boost: self.boost,
+            _name: self._name,
+            log: Logarithm { scaling_factor },
         }
     }
 
@@ -311,12 +280,10 @@ impl RankFeatureQuery {
     /// `saturation` function instead.
     pub fn sigmoid(self, pivot: f64, exponent: f64) -> RankFeatureSigmoidQuery {
         RankFeatureSigmoidQuery {
-            inner: InnerSigmoid {
-                field: self.inner.field,
-                boost: self.inner.boost,
-                _name: self.inner._name,
-                sigmoid: Sigmoid { pivot, exponent },
-            },
+            field: self.field,
+            boost: self.boost,
+            _name: self._name,
+            sigmoid: Sigmoid { pivot, exponent },
         }
     }
 
@@ -328,12 +295,10 @@ impl RankFeatureQuery {
     /// preserve only 9 significant bits for the precision.
     pub fn linear(self) -> RankFeatureLinearQuery {
         RankFeatureLinearQuery {
-            inner: InnerLinear {
-                field: self.inner.field,
-                boost: self.inner.boost,
-                _name: self.inner._name,
-                linear: Linear {},
-            },
+            field: self.field,
+            boost: self.boost,
+            _name: self._name,
+            linear: Linear {},
         }
     }
 
@@ -346,7 +311,7 @@ impl RankFeatureSaturationQuery {
     where
         T: Into<f64>,
     {
-        self.inner.saturation.pivot = Some(pivot.into());
+        self.saturation.pivot = Some(pivot.into());
         self
     }
 
@@ -370,6 +335,12 @@ impl ShouldSkip for RankFeatureSaturationQuery {}
 impl ShouldSkip for RankFeatureLogarithmQuery {}
 impl ShouldSkip for RankFeatureSigmoidQuery {}
 impl ShouldSkip for RankFeatureLinearQuery {}
+
+serialize_query!("rank_feature": RankFeatureQuery);
+serialize_query!("rank_feature": RankFeatureSaturationQuery);
+serialize_query!("rank_feature": RankFeatureLogarithmQuery);
+serialize_query!("rank_feature": RankFeatureSigmoidQuery);
+serialize_query!("rank_feature": RankFeatureLinearQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/script_query.rs
+++ b/src/search/queries/specialized/script_query.rs
@@ -15,13 +15,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct ScriptQuery {
-    #[serde(rename = "script")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     script: Script,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
@@ -38,11 +33,9 @@ impl Query {
     /// return a boolean value, `true` or `false`
     pub fn script(script: Script) -> ScriptQuery {
         ScriptQuery {
-            inner: Inner {
-                script,
-                boost: None,
-                _name: None,
-            },
+            script,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -52,6 +45,8 @@ impl ScriptQuery {
 }
 
 impl ShouldSkip for ScriptQuery {}
+
+serialize_query!("script": ScriptQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/script_score_query.rs
+++ b/src/search/queries/specialized/script_score_query.rs
@@ -18,13 +18,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-score-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct ScriptScoreQuery {
-    #[serde(rename = "script_score")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     query: Box<Query>,
 
     script: Script,
@@ -50,13 +45,11 @@ impl Query {
         Q: Into<Query>,
     {
         ScriptScoreQuery {
-            inner: Inner {
-                query: Box::new(query.into()),
-                script,
-                min_score: None,
-                boost: None,
-                _name: None,
-            },
+            query: Box::new(query.into()),
+            script,
+            min_score: None,
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -66,6 +59,8 @@ impl ScriptScoreQuery {
 }
 
 impl ShouldSkip for ScriptScoreQuery {}
+
+serialize_query!("script_score": ScriptScoreQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/wrapper_query.rs
+++ b/src/search/queries/specialized/wrapper_query.rs
@@ -16,14 +16,9 @@ use crate::util::*;
 /// Query::wrapper("eyJ0ZXJtIiA6IHsgInVzZXIuaWQiIDogImtpbWNoeSIgfX0=");
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wrapper-query.html>
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct WrapperQuery {
-    #[serde(rename = "wrapper")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize, Default)]
-struct Inner {
     query: String,
 }
 
@@ -34,14 +29,14 @@ impl Query {
         S: ToString,
     {
         WrapperQuery {
-            inner: Inner {
-                query: query.to_string(),
-            },
+            query: query.to_string(),
         }
     }
 }
 
 impl ShouldSkip for WrapperQuery {}
+
+serialize_query!("wrapper": WrapperQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/exists_query.rs
+++ b/src/search/queries/term_level/exists_query.rs
@@ -19,13 +19,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct ExistsQuery {
-    #[serde(rename = "exists")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     field: String,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
@@ -49,11 +44,9 @@ impl Query {
         T: Into<String>,
     {
         ExistsQuery {
-            inner: Inner {
-                field: field.into(),
-                boost: None,
-                _name: None,
-            },
+            field: field.into(),
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -63,6 +56,8 @@ impl ExistsQuery {
 }
 
 impl ShouldSkip for ExistsQuery {}
+
+serialize_query!("exists": ExistsQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/ids_query.rs
+++ b/src/search/queries/term_level/ids_query.rs
@@ -15,13 +15,8 @@ use std::collections::BTreeSet;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct IdsQuery {
-    #[serde(rename = "ids")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     values: BTreeSet<String>,
 
@@ -43,11 +38,9 @@ impl Query {
         I::Item: ToString,
     {
         IdsQuery {
-            inner: Inner {
-                values: values.into_iter().map(|value| value.to_string()).collect(),
-                boost: None,
-                _name: None,
-            },
+            values: values.into_iter().map(|value| value.to_string()).collect(),
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -58,9 +51,11 @@ impl IdsQuery {
 
 impl ShouldSkip for IdsQuery {
     fn should_skip(&self) -> bool {
-        self.inner.values.should_skip()
+        self.values.should_skip()
     }
 }
+
+serialize_query!("ids": IdsQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/terms_lookup_query.rs
+++ b/src/search/queries/term_level/terms_lookup_query.rs
@@ -27,13 +27,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct TermsLookupQuery {
-    #[serde(rename = "terms")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(flatten)]
     pair: KeyValuePair<String, TermsLookup>,
 
@@ -72,19 +67,17 @@ impl Query {
         V: ToString,
     {
         TermsLookupQuery {
-            inner: Inner {
-                pair: KeyValuePair::new(
-                    field.to_string(),
-                    TermsLookup {
-                        index: index.to_string(),
-                        id: id.to_string(),
-                        path: path.to_string(),
-                        routing: None,
-                    },
-                ),
-                boost: None,
-                _name: None,
-            },
+            pair: KeyValuePair::new(
+                field.to_string(),
+                TermsLookup {
+                    index: index.to_string(),
+                    id: id.to_string(),
+                    path: path.to_string(),
+                    routing: None,
+                },
+            ),
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -102,12 +95,14 @@ impl TermsLookupQuery {
     where
         S: ToString,
     {
-        self.inner.pair.value.routing = Some(routing.to_string());
+        self.pair.value.routing = Some(routing.to_string());
         self
     }
 }
 
 impl ShouldSkip for TermsLookupQuery {}
+
+serialize_query!("terms": TermsLookupQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/terms_query.rs
+++ b/src/search/queries/term_level/terms_query.rs
@@ -22,13 +22,8 @@ use crate::util::*;
 /// ```
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html>
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(remote = "Self")]
 pub struct TermsQuery {
-    #[serde(rename = "terms")]
-    inner: Inner,
-}
-
-#[derive(Debug, Clone, PartialEq, Serialize)]
-struct Inner {
     #[serde(flatten)]
     pair: KeyValuePair<String, Terms>,
 
@@ -57,11 +52,9 @@ impl Query {
         I: Into<Terms>,
     {
         TermsQuery {
-            inner: Inner {
-                pair: KeyValuePair::new(field.into(), values.into()),
-                boost: None,
-                _name: None,
-            },
+            pair: KeyValuePair::new(field.into(), values.into()),
+            boost: None,
+            _name: None,
         }
     }
 }
@@ -72,9 +65,11 @@ impl TermsQuery {
 
 impl ShouldSkip for TermsQuery {
     fn should_skip(&self) -> bool {
-        self.inner.pair.value.should_skip()
+        self.pair.value.should_skip()
     }
 }
+
+serialize_query!("terms": TermsQuery);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Until now, query serialization was required using an Inner type with optional custom serialization to serialize search queries correctly. This is because Elasticsearch queries are wrapped in a root object. This change adds a `serialize_query` macro that has to be used in pair with `#[serde(remote = "Self")]` attribute.

These changes remove redundant structures, simplify serialization, and debug formatted queries.
