### PR TITLE
Rename macros for reusability

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -56,7 +56,7 @@ macro_rules! add_aggregate {
 
 #[doc(hidden)]
 #[macro_export]
-macro_rules! serialize_query {
+macro_rules! serialize_with_root {
     ($root:tt : $inner:ty) => {
         impl $crate::serde::Serialize for $inner {
             fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
@@ -84,8 +84,12 @@ macro_rules! serialize_query {
             }
         }
     };
+}
 
-    (keyed, $root:tt : $inner:ty) => {
+#[doc(hidden)]
+#[macro_export]
+macro_rules! serialize_with_root_keyed {
+    ($root:tt : $inner:ty) => {
         impl $crate::serde::Serialize for $inner {
             fn serialize<S>(&self, serializer: S) -> ::std::result::Result<S::Ok, S::Error>
             where

--- a/src/search/queries/compound/bool_query.rs
+++ b/src/search/queries/compound/bool_query.rs
@@ -130,7 +130,7 @@ impl ShouldSkip for BoolQuery {
     }
 }
 
-serialize_query!("bool": BoolQuery);
+serialize_with_root!("bool": BoolQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/compound/boosting_query.rs
+++ b/src/search/queries/compound/boosting_query.rs
@@ -74,7 +74,7 @@ impl ShouldSkip for BoostingQuery {
     }
 }
 
-serialize_query!("boosting": BoostingQuery);
+serialize_with_root!("boosting": BoostingQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/compound/constant_score_query.rs
+++ b/src/search/queries/compound/constant_score_query.rs
@@ -58,7 +58,7 @@ impl ShouldSkip for ConstantScoreQuery {
     }
 }
 
-serialize_query!("constant_score": ConstantScoreQuery);
+serialize_with_root!("constant_score": ConstantScoreQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/compound/dis_max_query.rs
+++ b/src/search/queries/compound/dis_max_query.rs
@@ -96,7 +96,7 @@ impl ShouldSkip for DisMaxQuery {
     }
 }
 
-serialize_query!("dis_max": DisMaxQuery);
+serialize_with_root!("dis_max": DisMaxQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/compound/function_score_query.rs
+++ b/src/search/queries/compound/function_score_query.rs
@@ -132,7 +132,7 @@ impl ShouldSkip for FunctionScoreQuery {
     }
 }
 
-serialize_query!("function_score": FunctionScoreQuery);
+serialize_with_root!("function_score": FunctionScoreQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/combined_fields_query.rs
+++ b/src/search/queries/full_text/combined_fields_query.rs
@@ -121,7 +121,7 @@ impl ShouldSkip for CombinedFieldsQuery {
     }
 }
 
-serialize_query!("combined_fields": CombinedFieldsQuery);
+serialize_with_root!("combined_fields": CombinedFieldsQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/match_bool_prefix_query.rs
+++ b/src/search/queries/full_text/match_bool_prefix_query.rs
@@ -103,7 +103,7 @@ impl ShouldSkip for MatchBoolPrefixQuery {
     }
 }
 
-serialize_query!(keyed, "match_bool_prefix": MatchBoolPrefixQuery);
+serialize_with_root_keyed!("match_bool_prefix": MatchBoolPrefixQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/match_phrase_prefix_query.rs
+++ b/src/search/queries/full_text/match_phrase_prefix_query.rs
@@ -112,7 +112,7 @@ impl ShouldSkip for MatchPhrasePrefixQuery {
     }
 }
 
-serialize_query!(keyed, "match_phrase_prefix": MatchPhrasePrefixQuery);
+serialize_with_root_keyed!("match_phrase_prefix": MatchPhrasePrefixQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/match_phrase_query.rs
+++ b/src/search/queries/full_text/match_phrase_query.rs
@@ -93,7 +93,7 @@ impl ShouldSkip for MatchPhraseQuery {
     }
 }
 
-serialize_query!(keyed, "match_phrase": MatchPhraseQuery);
+serialize_with_root_keyed!("match_phrase": MatchPhraseQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/match_query.rs
+++ b/src/search/queries/full_text/match_query.rs
@@ -219,7 +219,7 @@ impl ShouldSkip for MatchQuery {
     }
 }
 
-serialize_query!(keyed, "match": MatchQuery);
+serialize_with_root_keyed!("match": MatchQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/multi_match_query.rs
+++ b/src/search/queries/full_text/multi_match_query.rs
@@ -239,7 +239,7 @@ impl ShouldSkip for MultiMatchQuery {
     }
 }
 
-serialize_query!("multi_match": MultiMatchQuery);
+serialize_with_root!("multi_match": MultiMatchQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/query_string_query.rs
+++ b/src/search/queries/full_text/query_string_query.rs
@@ -375,7 +375,7 @@ impl ShouldSkip for QueryStringQuery {
     }
 }
 
-serialize_query!("query_string": QueryStringQuery);
+serialize_with_root!("query_string": QueryStringQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/full_text/simple_query_string_query.rs
+++ b/src/search/queries/full_text/simple_query_string_query.rs
@@ -246,7 +246,7 @@ impl ShouldSkip for SimpleQueryStringQuery {
     }
 }
 
-serialize_query!("simple_query_string": SimpleQueryStringQuery);
+serialize_with_root!("simple_query_string": SimpleQueryStringQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/geo/geo_bounding_box_query.rs
+++ b/src/search/queries/geo/geo_bounding_box_query.rs
@@ -58,7 +58,7 @@ impl ShouldSkip for GeoBoundingBoxQuery {
     }
 }
 
-serialize_query!("geo_bounding_box": GeoBoundingBoxQuery);
+serialize_with_root!("geo_bounding_box": GeoBoundingBoxQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/geo/geo_distance_query.rs
+++ b/src/search/queries/geo/geo_distance_query.rs
@@ -75,7 +75,7 @@ impl ShouldSkip for GeoDistanceQuery {
     }
 }
 
-serialize_query!("geo_distance": GeoDistanceQuery);
+serialize_with_root!("geo_distance": GeoDistanceQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/geo/geo_shape_lookup_query.rs
+++ b/src/search/queries/geo/geo_shape_lookup_query.rs
@@ -134,7 +134,7 @@ impl GeoShapeLookupQuery {
 
 impl ShouldSkip for GeoShapeLookupQuery {}
 
-serialize_query!("geo_shape": GeoShapeLookupQuery);
+serialize_with_root!("geo_shape": GeoShapeLookupQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/geo/geo_shape_query.rs
+++ b/src/search/queries/geo/geo_shape_query.rs
@@ -88,7 +88,7 @@ impl GeoShapeQuery {
 
 impl ShouldSkip for GeoShapeQuery {}
 
-serialize_query!("geo_shape": GeoShapeQuery);
+serialize_with_root!("geo_shape": GeoShapeQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/joining/has_child_query.rs
+++ b/src/search/queries/joining/has_child_query.rs
@@ -105,7 +105,7 @@ impl ShouldSkip for HasChildQuery {
     }
 }
 
-serialize_query!("has_child": HasChildQuery);
+serialize_with_root!("has_child": HasChildQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/joining/has_parent_query.rs
+++ b/src/search/queries/joining/has_parent_query.rs
@@ -89,7 +89,7 @@ impl ShouldSkip for HasParentQuery {
     }
 }
 
-serialize_query!("has_parent": HasParentQuery);
+serialize_with_root!("has_parent": HasParentQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/joining/nested_query.rs
+++ b/src/search/queries/joining/nested_query.rs
@@ -135,7 +135,7 @@ impl ShouldSkip for NestedQuery {
     }
 }
 
-serialize_query!("nested": NestedQuery);
+serialize_with_root!("nested": NestedQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/joining/parent_id_query.rs
+++ b/src/search/queries/joining/parent_id_query.rs
@@ -71,7 +71,7 @@ impl ShouldSkip for ParentIdQuery {
     }
 }
 
-serialize_query!("parent_id": ParentIdQuery);
+serialize_with_root!("parent_id": ParentIdQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/match_all_query.rs
+++ b/src/search/queries/match_all_query.rs
@@ -25,7 +25,7 @@ pub struct MatchAllQuery {
     _name: Option<String>,
 }
 
-serialize_query!("match_all": MatchAllQuery);
+serialize_with_root!("match_all": MatchAllQuery);
 
 impl Query {
     /// Creates an instance of [`MatchAllQuery`]

--- a/src/search/queries/match_none_query.rs
+++ b/src/search/queries/match_none_query.rs
@@ -36,7 +36,7 @@ impl MatchNoneQuery {
     add_boost_and_name!();
 }
 
-serialize_query!("match_none": MatchNoneQuery);
+serialize_with_root!("match_none": MatchNoneQuery);
 
 impl ShouldSkip for MatchNoneQuery {}
 

--- a/src/search/queries/shape/shape_lookup_query.rs
+++ b/src/search/queries/shape/shape_lookup_query.rs
@@ -126,7 +126,7 @@ impl ShapeLookupQuery {
 
 impl ShouldSkip for ShapeLookupQuery {}
 
-serialize_query!("shape": ShapeLookupQuery);
+serialize_with_root!("shape": ShapeLookupQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/shape/shape_query.rs
+++ b/src/search/queries/shape/shape_query.rs
@@ -80,7 +80,7 @@ impl ShapeQuery {
 
 impl ShouldSkip for ShapeQuery {}
 
-serialize_query!("shape": ShapeQuery);
+serialize_with_root!("shape": ShapeQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/distance_feature_query.rs
+++ b/src/search/queries/specialized/distance_feature_query.rs
@@ -171,8 +171,8 @@ where
 
 impl<O> ShouldSkip for DistanceFeatureQuery<O> where O: Origin {}
 
-serialize_query!("distance_feature": DistanceFeatureQuery<DateTime<Utc>>);
-serialize_query!("distance_feature": DistanceFeatureQuery<GeoPoint>);
+serialize_with_root!("distance_feature": DistanceFeatureQuery<DateTime<Utc>>);
+serialize_with_root!("distance_feature": DistanceFeatureQuery<GeoPoint>);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/more_like_this_query.rs
+++ b/src/search/queries/specialized/more_like_this_query.rs
@@ -366,7 +366,7 @@ impl ShouldSkip for MoreLikeThisQuery {
     }
 }
 
-serialize_query!("more_like_this": MoreLikeThisQuery);
+serialize_with_root!("more_like_this": MoreLikeThisQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/percolate_lookup_query.rs
+++ b/src/search/queries/specialized/percolate_lookup_query.rs
@@ -104,7 +104,7 @@ impl PercolateLookupQuery {
 
 impl ShouldSkip for PercolateLookupQuery {}
 
-serialize_query!("percolate": PercolateLookupQuery);
+serialize_with_root!("percolate": PercolateLookupQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/percolate_query.rs
+++ b/src/search/queries/specialized/percolate_query.rs
@@ -77,7 +77,7 @@ impl ShouldSkip for PercolateQuery {
     }
 }
 
-serialize_query!("percolate": PercolateQuery);
+serialize_with_root!("percolate": PercolateQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/pinned_query.rs
+++ b/src/search/queries/specialized/pinned_query.rs
@@ -56,7 +56,7 @@ impl ShouldSkip for PinnedQuery {
     }
 }
 
-serialize_query!("pinned": PinnedQuery);
+serialize_with_root!("pinned": PinnedQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/rank_feature_query.rs
+++ b/src/search/queries/specialized/rank_feature_query.rs
@@ -336,11 +336,11 @@ impl ShouldSkip for RankFeatureLogarithmQuery {}
 impl ShouldSkip for RankFeatureSigmoidQuery {}
 impl ShouldSkip for RankFeatureLinearQuery {}
 
-serialize_query!("rank_feature": RankFeatureQuery);
-serialize_query!("rank_feature": RankFeatureSaturationQuery);
-serialize_query!("rank_feature": RankFeatureLogarithmQuery);
-serialize_query!("rank_feature": RankFeatureSigmoidQuery);
-serialize_query!("rank_feature": RankFeatureLinearQuery);
+serialize_with_root!("rank_feature": RankFeatureQuery);
+serialize_with_root!("rank_feature": RankFeatureSaturationQuery);
+serialize_with_root!("rank_feature": RankFeatureLogarithmQuery);
+serialize_with_root!("rank_feature": RankFeatureSigmoidQuery);
+serialize_with_root!("rank_feature": RankFeatureLinearQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/script_query.rs
+++ b/src/search/queries/specialized/script_query.rs
@@ -46,7 +46,7 @@ impl ScriptQuery {
 
 impl ShouldSkip for ScriptQuery {}
 
-serialize_query!("script": ScriptQuery);
+serialize_with_root!("script": ScriptQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/script_score_query.rs
+++ b/src/search/queries/specialized/script_score_query.rs
@@ -60,7 +60,7 @@ impl ScriptScoreQuery {
 
 impl ShouldSkip for ScriptScoreQuery {}
 
-serialize_query!("script_score": ScriptScoreQuery);
+serialize_with_root!("script_score": ScriptScoreQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/specialized/wrapper_query.rs
+++ b/src/search/queries/specialized/wrapper_query.rs
@@ -36,7 +36,7 @@ impl Query {
 
 impl ShouldSkip for WrapperQuery {}
 
-serialize_query!("wrapper": WrapperQuery);
+serialize_with_root!("wrapper": WrapperQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/exists_query.rs
+++ b/src/search/queries/term_level/exists_query.rs
@@ -57,7 +57,7 @@ impl ExistsQuery {
 
 impl ShouldSkip for ExistsQuery {}
 
-serialize_query!("exists": ExistsQuery);
+serialize_with_root!("exists": ExistsQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/fuzzy_query.rs
+++ b/src/search/queries/term_level/fuzzy_query.rs
@@ -136,7 +136,7 @@ impl ShouldSkip for FuzzyQuery {
     }
 }
 
-serialize_query!(keyed, "fuzzy": FuzzyQuery);
+serialize_with_root_keyed!("fuzzy": FuzzyQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/ids_query.rs
+++ b/src/search/queries/term_level/ids_query.rs
@@ -55,7 +55,7 @@ impl ShouldSkip for IdsQuery {
     }
 }
 
-serialize_query!("ids": IdsQuery);
+serialize_with_root!("ids": IdsQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/prefix_query.rs
+++ b/src/search/queries/term_level/prefix_query.rs
@@ -89,7 +89,7 @@ impl ShouldSkip for PrefixQuery {
     }
 }
 
-serialize_query!(keyed, "prefix": PrefixQuery);
+serialize_with_root_keyed!("prefix": PrefixQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/range_query.rs
+++ b/src/search/queries/term_level/range_query.rs
@@ -165,7 +165,7 @@ impl ShouldSkip for RangeQuery {
     }
 }
 
-serialize_query!(keyed, "range": RangeQuery);
+serialize_with_root_keyed!("range": RangeQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/regexp_query.rs
+++ b/src/search/queries/term_level/regexp_query.rs
@@ -126,7 +126,7 @@ impl ShouldSkip for RegexpQuery {
     }
 }
 
-serialize_query!(keyed, "regexp": RegexpQuery);
+serialize_with_root_keyed!("regexp": RegexpQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/term_query.rs
+++ b/src/search/queries/term_level/term_query.rs
@@ -68,7 +68,7 @@ impl ShouldSkip for TermQuery {
     }
 }
 
-serialize_query!(keyed, "term": TermQuery);
+serialize_with_root_keyed!("term": TermQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/terms_lookup_query.rs
+++ b/src/search/queries/term_level/terms_lookup_query.rs
@@ -102,7 +102,7 @@ impl TermsLookupQuery {
 
 impl ShouldSkip for TermsLookupQuery {}
 
-serialize_query!("terms": TermsLookupQuery);
+serialize_with_root!("terms": TermsLookupQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/terms_query.rs
+++ b/src/search/queries/term_level/terms_query.rs
@@ -69,7 +69,7 @@ impl ShouldSkip for TermsQuery {
     }
 }
 
-serialize_query!("terms": TermsQuery);
+serialize_with_root!("terms": TermsQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/terms_set_query.rs
+++ b/src/search/queries/term_level/terms_set_query.rs
@@ -77,7 +77,7 @@ impl ShouldSkip for TermsSetQuery {
     }
 }
 
-serialize_query!(keyed, "terms_set": TermsSetQuery);
+serialize_with_root_keyed!("terms_set": TermsSetQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/wildcard_query.rs
+++ b/src/search/queries/term_level/wildcard_query.rs
@@ -84,7 +84,7 @@ impl ShouldSkip for WildcardQuery {
     }
 }
 
-serialize_query!(keyed, "wildcard": WildcardQuery);
+serialize_with_root_keyed!("wildcard": WildcardQuery);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/sort/geo_distance_sort.rs
+++ b/src/search/sort/geo_distance_sort.rs
@@ -122,7 +122,7 @@ impl IntoIterator for GeoDistanceSort {
     }
 }
 
-serialize_query!("_geo_distance": GeoDistanceSort);
+serialize_with_root!("_geo_distance": GeoDistanceSort);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
`serialize_query!` does what it needs to, but it can be used for other kind of structures too, renaming to `serialize_with_root` to reveal the intention.