### PR TITLE
Fix enums with incorrectly used untagged variant.

### DIFF
--- a/src/search/highlight/encoder.rs
+++ b/src/search/highlight/encoder.rs
@@ -1,6 +1,6 @@
 /// Indicates if the snippet should be HTML encoded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum Encoder {
     /// No encoding
     Default,

--- a/src/search/highlight/fragmenter.rs
+++ b/src/search/highlight/fragmenter.rs
@@ -1,6 +1,6 @@
 /// Specifies how text should be broken up in highlight snippets.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-#[serde(untagged, rename_all = "snake_case")]
+#[serde(rename_all = "snake_case")]
 pub enum Fragmenter {
     /// Breaks up text into same-sized fragments.
     Simple,


### PR DESCRIPTION
Using untagged macro attribute will screw enums serialization up - removing it.