### PR TITLE
Remove redundant TryInto operators

### DIFF
--- a/src/search/queries/specialized/percolate_lookup_query.rs
+++ b/src/search/queries/specialized/percolate_lookup_query.rs
@@ -1,6 +1,5 @@
 use crate::search::*;
 use crate::util::*;
-use std::convert::TryInto;
 
 /// In order to percolate a newly indexed document, the [percolate](PercolateLookupQuery) query can
 /// be used. Based on the response from an index request, the `_id` and other meta information can
@@ -81,13 +80,8 @@ impl PercolateLookupQuery {
     }
 
     /// The expected version of the document to be fetched
-    pub fn version<S>(mut self, version: S) -> Self
-    where
-        S: TryInto<u64>,
-    {
-        if let Ok(version) = version.try_into() {
-            self.version = Some(version);
-        }
+    pub fn version(mut self, version: u64) -> Self {
+        self.version = Some(version);
         self
     }
 

--- a/src/search/request.rs
+++ b/src/search/request.rs
@@ -113,26 +113,16 @@ impl Search {
     /// Starting document offset.
     ///
     /// Defaults to `0`.
-    pub fn from<S>(mut self, from: S) -> Self
-    where
-        S: TryInto<u64>,
-    {
-        if let Ok(from) = from.try_into() {
-            self.from = Some(from);
-        }
+    pub fn from(mut self, from: u64) -> Self {
+        self.from = Some(from);
         self
     }
 
     /// The number of hits to return.
     ///
     /// Defaults to `10`.
-    pub fn size<S>(mut self, size: S) -> Self
-    where
-        S: TryInto<u64>,
-    {
-        if let Ok(size) = size.try_into() {
-            self.size = Some(size);
-        }
+    pub fn size(mut self, size: u64) -> Self {
+        self.size = Some(size);
         self
     }
 


### PR DESCRIPTION
There's no point to have TryInto for u64 operators, use simpler types.

