### PR TITLE
Add serialization wrapper for other container queries

### DIFF
--- a/src/search/queries/geo/geo_bounding_box_query.rs
+++ b/src/search/queries/geo/geo_bounding_box_query.rs
@@ -10,8 +10,11 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(remote = "Self")]
 pub struct GeoBoundingBoxQuery {
-    #[serde(flatten)]
-    pair: KeyValuePair<String, GeoBoundingBox>,
+    #[serde(skip)]
+    field: String,
+
+    #[serde(skip)]
+    bounding_box: GeoBoundingBox,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     validation_method: Option<ValidationMethod>,
@@ -26,14 +29,15 @@ impl Query {
     /// Creates an instance of [`GeoBoundingBoxQuery`]
     ///
     /// - `field` - Field you wish to search.
-    /// - `value` - A series of vertex coordinates of a geo bounding box
-    pub fn geo_bounding_box<T, U>(field: T, value: U) -> GeoBoundingBoxQuery
+    /// - `bounding_box` - A series of vertex coordinates of a geo bounding box
+    pub fn geo_bounding_box<T, U>(field: T, bounding_box: U) -> GeoBoundingBoxQuery
     where
         T: ToString,
         U: Into<GeoBoundingBox>,
     {
         GeoBoundingBoxQuery {
-            pair: KeyValuePair::new(field.to_string(), value.into()),
+            field: field.to_string(),
+            bounding_box: bounding_box.into(),
             validation_method: None,
             boost: None,
             _name: None,
@@ -52,13 +56,9 @@ impl GeoBoundingBoxQuery {
     add_boost_and_name!();
 }
 
-impl ShouldSkip for GeoBoundingBoxQuery {
-    fn should_skip(&self) -> bool {
-        self.pair.key.should_skip()
-    }
-}
+impl ShouldSkip for GeoBoundingBoxQuery {}
 
-serialize_with_root!("geo_bounding_box": GeoBoundingBoxQuery);
+serialize_with_root_key_value_pair!("geo_bounding_box": GeoBoundingBoxQuery, field, bounding_box);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/geo/geo_distance_query.rs
+++ b/src/search/queries/geo/geo_distance_query.rs
@@ -9,8 +9,11 @@ use crate::util::*;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(remote = "Self")]
 pub struct GeoDistanceQuery {
-    #[serde(flatten)]
-    pair: KeyValuePair<String, GeoPoint>,
+    #[serde(skip)]
+    field: String,
+
+    #[serde(skip)]
+    location: GeoPoint,
 
     distance: Distance,
 
@@ -40,7 +43,8 @@ impl Query {
         V: Into<Distance>,
     {
         GeoDistanceQuery {
-            pair: KeyValuePair::new(field.to_string(), origin.into()),
+            field: field.to_string(),
+            location: origin.into(),
             distance: distance.into(),
             distance_type: None,
             validation_method: None,
@@ -69,13 +73,9 @@ impl GeoDistanceQuery {
     add_boost_and_name!();
 }
 
-impl ShouldSkip for GeoDistanceQuery {
-    fn should_skip(&self) -> bool {
-        self.pair.key.should_skip()
-    }
-}
+impl ShouldSkip for GeoDistanceQuery {}
 
-serialize_with_root!("geo_distance": GeoDistanceQuery);
+serialize_with_root_key_value_pair!("geo_distance": GeoDistanceQuery, field, location);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/geo/geo_shape_query.rs
+++ b/src/search/queries/geo/geo_shape_query.rs
@@ -18,8 +18,11 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(remote = "Self")]
 pub struct GeoShapeQuery {
-    #[serde(flatten)]
-    pair: KeyValuePair<String, InlineShape>,
+    #[serde(skip)]
+    field: String,
+
+    #[serde(skip)]
+    shape: InlineShape,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     ignore_unmapped: Option<bool>,
@@ -50,13 +53,11 @@ impl Query {
         T: Into<GeoShape>,
     {
         GeoShapeQuery {
-            pair: KeyValuePair::new(
-                field.to_string(),
-                InlineShape {
-                    shape: shape.into(),
-                    relation: None,
-                },
-            ),
+            field: field.to_string(),
+            shape: InlineShape {
+                shape: shape.into(),
+                relation: None,
+            },
             ignore_unmapped: None,
             boost: None,
             _name: None,
@@ -69,7 +70,7 @@ impl GeoShapeQuery {
     /// mapping parameter determines which spatial relation operators may be
     /// used at search time.
     pub fn relation(mut self, relation: SpatialRelation) -> Self {
-        self.pair.value.relation = Some(relation);
+        self.shape.relation = Some(relation);
         self
     }
 
@@ -88,7 +89,7 @@ impl GeoShapeQuery {
 
 impl ShouldSkip for GeoShapeQuery {}
 
-serialize_with_root!("geo_shape": GeoShapeQuery);
+serialize_with_root_key_value_pair!("geo_shape": GeoShapeQuery, field, shape);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/shape/shape_lookup_query.rs
+++ b/src/search/queries/shape/shape_lookup_query.rs
@@ -10,8 +10,11 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(remote = "Self")]
 pub struct ShapeLookupQuery {
-    #[serde(flatten)]
-    pair: KeyValuePair<String, Shape>,
+    #[serde(skip)]
+    field: String,
+
+    #[serde(skip)]
+    shape: Shape,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     ignore_unmapped: Option<bool>,
@@ -56,18 +59,16 @@ impl Query {
         T: ToString,
     {
         ShapeLookupQuery {
-            pair: KeyValuePair::new(
-                field.to_string(),
-                Shape {
-                    indexed_shape: IndexedShape {
-                        id: id.to_string(),
-                        index: None,
-                        path: None,
-                        routing: None,
-                    },
-                    relation: None,
+            field: field.to_string(),
+            shape: Shape {
+                indexed_shape: IndexedShape {
+                    id: id.to_string(),
+                    index: None,
+                    path: None,
+                    routing: None,
                 },
-            ),
+                relation: None,
+            },
             ignore_unmapped: None,
             boost: None,
             _name: None,
@@ -81,7 +82,7 @@ impl ShapeLookupQuery {
     where
         S: ToString,
     {
-        self.pair.value.indexed_shape.index = Some(index.to_string());
+        self.shape.indexed_shape.index = Some(index.to_string());
         self
     }
 
@@ -90,7 +91,7 @@ impl ShapeLookupQuery {
     where
         S: ToString,
     {
-        self.pair.value.indexed_shape.path = Some(path.to_string());
+        self.shape.indexed_shape.path = Some(path.to_string());
         self
     }
 
@@ -99,7 +100,7 @@ impl ShapeLookupQuery {
     where
         S: ToString,
     {
-        self.pair.value.indexed_shape.routing = Some(routing.to_string());
+        self.shape.indexed_shape.routing = Some(routing.to_string());
         self
     }
 
@@ -107,7 +108,7 @@ impl ShapeLookupQuery {
     /// mapping parameter determines which spatial relation operators may be
     /// used at search time.
     pub fn relation(mut self, relation: SpatialRelation) -> Self {
-        self.pair.value.relation = Some(relation);
+        self.shape.relation = Some(relation);
         self
     }
 
@@ -126,7 +127,7 @@ impl ShapeLookupQuery {
 
 impl ShouldSkip for ShapeLookupQuery {}
 
-serialize_with_root!("shape": ShapeLookupQuery);
+serialize_with_root_key_value_pair!("shape": ShapeLookupQuery, field, shape);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/shape/shape_query.rs
+++ b/src/search/queries/shape/shape_query.rs
@@ -10,8 +10,11 @@ use serde::Serialize;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(remote = "Self")]
 pub struct ShapeQuery {
-    #[serde(flatten)]
-    pair: KeyValuePair<String, InlineShape>,
+    #[serde(skip)]
+    field: String,
+
+    #[serde(skip)]
+    shape: InlineShape,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     ignore_unmapped: Option<bool>,
@@ -42,13 +45,11 @@ impl Query {
         T: Into<Shape>,
     {
         ShapeQuery {
-            pair: KeyValuePair::new(
-                field.to_string(),
-                InlineShape {
-                    shape: shape.into(),
-                    relation: None,
-                },
-            ),
+            field: field.to_string(),
+            shape: InlineShape {
+                shape: shape.into(),
+                relation: None,
+            },
             ignore_unmapped: None,
             boost: None,
             _name: None,
@@ -61,7 +62,7 @@ impl ShapeQuery {
     /// mapping parameter determines which spatial relation operators may be
     /// used at search time.
     pub fn relation(mut self, relation: SpatialRelation) -> Self {
-        self.pair.value.relation = Some(relation);
+        self.shape.relation = Some(relation);
         self
     }
 
@@ -80,7 +81,7 @@ impl ShapeQuery {
 
 impl ShouldSkip for ShapeQuery {}
 
-serialize_with_root!("shape": ShapeQuery);
+serialize_with_root_key_value_pair!("shape": ShapeQuery, field, shape);
 
 #[cfg(test)]
 mod tests {

--- a/src/search/queries/term_level/terms_lookup_query.rs
+++ b/src/search/queries/term_level/terms_lookup_query.rs
@@ -29,8 +29,11 @@ use crate::util::*;
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(remote = "Self")]
 pub struct TermsLookupQuery {
-    #[serde(flatten)]
-    pair: KeyValuePair<String, TermsLookup>,
+    #[serde(skip)]
+    field: String,
+
+    #[serde(skip)]
+    terms_lookup: TermsLookup,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     boost: Option<Boost>,
@@ -67,15 +70,13 @@ impl Query {
         V: ToString,
     {
         TermsLookupQuery {
-            pair: KeyValuePair::new(
-                field.to_string(),
-                TermsLookup {
-                    index: index.to_string(),
-                    id: id.to_string(),
-                    path: path.to_string(),
-                    routing: None,
-                },
-            ),
+            field: field.to_string(),
+            terms_lookup: TermsLookup {
+                index: index.to_string(),
+                id: id.to_string(),
+                path: path.to_string(),
+                routing: None,
+            },
             boost: None,
             _name: None,
         }
@@ -95,14 +96,14 @@ impl TermsLookupQuery {
     where
         S: ToString,
     {
-        self.pair.value.routing = Some(routing.to_string());
+        self.terms_lookup.routing = Some(routing.to_string());
         self
     }
 }
 
 impl ShouldSkip for TermsLookupQuery {}
 
-serialize_with_root!("terms": TermsLookupQuery);
+serialize_with_root_key_value_pair!("terms": TermsLookupQuery, field, terms_lookup);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Getting rid of KeyValuePair helper from the query structures. It is fine for serialization, but should not be used in the actual structures. I'll remove it from the other structures as well, the intention is to only use it in serialization helpers.