### PR TITLE
Use consistent Map, Set types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,7 @@ extern crate serde_json;
 // Macro modules
 #[macro_use]
 mod macros;
+mod types;
 
 // Crate modules
 #[macro_use]
@@ -127,3 +128,4 @@ pub mod search;
 // Public re-exports
 pub use self::analyze::*;
 pub use self::search::*;
+pub use self::types::*;

--- a/src/search/aggregations/mod.rs
+++ b/src/search/aggregations/mod.rs
@@ -18,6 +18,8 @@ pub mod metrics;
 pub mod params;
 pub mod pipeline;
 
+use crate::Map;
+
 pub use self::bucket::*;
 pub use self::metrics::*;
 pub use self::params::*;
@@ -71,4 +73,4 @@ aggregation!(
 );
 
 /// Type alias for a collection of aggregations
-pub type Aggregations = std::collections::BTreeMap<AggregationName, Aggregation>;
+pub type Aggregations = Map<AggregationName, Aggregation>;

--- a/src/search/queries/params/pinned_query.rs
+++ b/src/search/queries/params/pinned_query.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use crate::Set;
 
 /// Ids or documents to filter by
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -6,10 +6,10 @@ use std::collections::BTreeSet;
 pub enum PinnedQueryValues {
     /// [Document IDs](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html)
     /// listed in the order they are to appear in results.
-    Ids(BTreeSet<String>),
+    Ids(Set<String>),
 
     /// Documents listed in the order they are to appear in results.
-    Docs(BTreeSet<PinnedDocument>),
+    Docs(Set<PinnedDocument>),
 }
 
 /// Pinned document

--- a/src/search/queries/params/script_object.rs
+++ b/src/search/queries/params/script_object.rs
@@ -7,9 +7,8 @@
 //!
 //! <https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html>
 
-use crate::util::*;
+use crate::{util::*, Map};
 use serde::{Serialize, Serializer};
-use std::collections::BTreeMap;
 
 /// Wherever scripting is supported in the Elasticsearch APIs, the syntax follows the same pattern;
 /// you specify the language of your script, provide the script logic (or source, and add parameters
@@ -25,7 +24,7 @@ pub struct Script {
     lang: Option<ScriptLang>,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    params: BTreeMap<String, serde_json::Value>,
+    params: Map<String, serde_json::Value>,
 }
 
 /// The script itself, which you specify as `source` for an inline script or
@@ -51,7 +50,7 @@ impl Script {
         Self {
             source: ScriptSource::Source(source.to_string()),
             lang: None,
-            params: BTreeMap::new(),
+            params: Map::new(),
         }
     }
 
@@ -63,7 +62,7 @@ impl Script {
         Self {
             source: ScriptSource::Id(id.to_string()),
             lang: None,
-            params: BTreeMap::new(),
+            params: Map::new(),
         }
     }
 

--- a/src/search/queries/specialized/more_like_this_query.rs
+++ b/src/search/queries/specialized/more_like_this_query.rs
@@ -1,6 +1,6 @@
 use crate::search::*;
 use crate::util::*;
-use std::collections::BTreeSet;
+use crate::Set;
 
 /// The More Like This Query finds documents that are "like" a given set of documents.
 /// In order to do so, MLT selects a set of representative terms of these input documents,
@@ -147,7 +147,7 @@ pub struct Document {
     _source: Option<SourceFilter>,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    _stored_fields: BTreeSet<String>,
+    _stored_fields: Set<String>,
 }
 
 impl Document {
@@ -160,7 +160,7 @@ impl Document {
     {
         Self {
             _id: id.to_string(),
-            _stored_fields: BTreeSet::new(),
+            _stored_fields: Set::new(),
             _index: None,
             _routing: None,
             _source: None,

--- a/src/search/queries/term_level/ids_query.rs
+++ b/src/search/queries/term_level/ids_query.rs
@@ -1,6 +1,6 @@
 use crate::search::*;
 use crate::util::*;
-use std::collections::BTreeSet;
+use crate::Set;
 
 /// Returns documents based on their IDs. This query uses document IDs stored in the
 /// [`_id`](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html)
@@ -18,7 +18,7 @@ use std::collections::BTreeSet;
 #[serde(remote = "Self")]
 pub struct IdsQuery {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    values: BTreeSet<String>,
+    values: Set<String>,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     boost: Option<Boost>,

--- a/src/search/request.rs
+++ b/src/search/request.rs
@@ -1,7 +1,8 @@
 //! Allows you to execute a search query and get back search hits that match the query.
 use crate::search::*;
 use crate::util::*;
-use std::{collections::BTreeMap, convert::TryInto};
+use crate::Map;
+use std::convert::TryInto;
 
 /// Returns search hits that match the query defined in the request.
 ///
@@ -9,7 +10,7 @@ use std::{collections::BTreeMap, convert::TryInto};
 #[derive(Debug, Default, Clone, Serialize, PartialEq)]
 pub struct Search {
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    runtime_mappings: BTreeMap<String, RuntimeMapping>,
+    runtime_mappings: Map<String, RuntimeMapping>,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     indices_boost: Vec<KeyValuePair<String, Boost>>,
@@ -48,7 +49,7 @@ pub struct Search {
     rescore: RescoreCollection,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    suggest: BTreeMap<String, Suggester>,
+    suggest: Map<String, Suggester>,
 }
 
 impl Search {

--- a/src/search/response/error_cause.rs
+++ b/src/search/response/error_cause.rs
@@ -1,6 +1,5 @@
-use crate::util::ShouldSkip;
+use crate::{util::ShouldSkip, Map};
 use serde_json::Value;
-use std::collections::HashMap;
 
 /// Error cause
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -28,5 +27,5 @@ pub struct ErrorCause {
 
     /// Additional fields that are not part of the strongly typed error cause
     #[serde(skip_serializing_if = "ShouldSkip::should_skip", default, flatten)]
-    pub additional_details: HashMap<String, Value>,
+    pub additional_details: Map<String, Value>,
 }

--- a/src/search/response/hit.rs
+++ b/src/search/response/hit.rs
@@ -1,8 +1,7 @@
 use super::{Explanation, NestedIdentity, Source};
-use crate::{util::ShouldSkip, InnerHitsResult};
+use crate::{util::ShouldSkip, InnerHitsResult, Map};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use std::collections::HashMap;
 
 /// Represents a single matched document
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -41,11 +40,11 @@ pub struct Hit {
 
     /// Highlighted matches
     #[serde(skip_serializing_if = "ShouldSkip::should_skip", default)]
-    pub highlight: HashMap<String, Vec<String>>,
+    pub highlight: Map<String, Vec<String>>,
 
     /// Inner hits
     #[serde(skip_serializing_if = "ShouldSkip::should_skip", default)]
-    pub inner_hits: HashMap<String, InnerHitsResult>,
+    pub inner_hits: Map<String, InnerHitsResult>,
 
     /// Matched queries
     #[serde(skip_serializing_if = "ShouldSkip::should_skip", default)]
@@ -57,7 +56,7 @@ pub struct Hit {
 
     /// Field values for the documents. Need to be specified in the request
     #[serde(skip_serializing_if = "ShouldSkip::should_skip", default)]
-    pub fields: HashMap<String, Value>,
+    pub fields: Map<String, Value>,
 }
 
 impl Hit {

--- a/src/search/response/search_response.rs
+++ b/src/search/response/search_response.rs
@@ -1,8 +1,7 @@
 use super::{ClusterStatistics, HitsMetadata, ShardStatistics, Suggest};
-use crate::util::ShouldSkip;
+use crate::{util::ShouldSkip, Map};
 use serde::de::DeserializeOwned;
 use serde_json::Value;
-use std::collections::{BTreeMap, HashMap};
 
 /// Search response
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -23,7 +22,7 @@ pub struct SearchResponse {
 
     /// Dynamically fetched fields
     #[serde(skip_serializing_if = "ShouldSkip::should_skip", default)]
-    pub fields: HashMap<String, Value>,
+    pub fields: Map<String, Value>,
 
     /// Point in time Id
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
@@ -55,7 +54,7 @@ pub struct SearchResponse {
 
     /// Suggest response
     #[serde(skip_serializing_if = "ShouldSkip::should_skip", default)]
-    pub suggest: BTreeMap<String, Vec<Suggest>>,
+    pub suggest: Map<String, Vec<Suggest>>,
 }
 
 impl SearchResponse {
@@ -202,7 +201,7 @@ mod tests {
             num_reduce_phases: None,
             max_score: None,
             clusters: None,
-            suggest: BTreeMap::from([
+            suggest: Map::from([
                 (
                     "song-suggest".to_string(),
                     vec![Suggest {

--- a/src/search/response/suggest_option.rs
+++ b/src/search/response/suggest_option.rs
@@ -1,6 +1,5 @@
-use crate::util::ShouldSkip;
+use crate::{util::ShouldSkip, Map};
 use serde::de::DeserializeOwned;
-use std::collections::BTreeMap;
 
 /// Suggester response option variants
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
@@ -59,7 +58,7 @@ pub struct CompletionSuggestOption {
     ///
     /// Contexts always return either as a category or as geohash
     #[serde(default, skip_serializing_if = "ShouldSkip::should_skip")]
-    pub contexts: BTreeMap<String, Vec<String>>,
+    pub contexts: Map<String, Vec<String>>,
 }
 
 impl CompletionSuggestOption {

--- a/src/search/suggesters/completion_suggester.rs
+++ b/src/search/suggesters/completion_suggester.rs
@@ -1,6 +1,5 @@
 use super::{SuggestContextQuery, SuggestFuzziness, Suggester};
-use crate::util::ShouldSkip;
-use std::collections::BTreeMap;
+use crate::{util::ShouldSkip, Map};
 
 /// The `completion` suggester provides auto-complete/search-as-you-type functionality. This is a
 /// navigational feature to guide users to relevant results as they are typing, improving search
@@ -35,7 +34,7 @@ struct CompletionSuggesterCompletion {
     skip_duplicates: Option<bool>,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    contexts: BTreeMap<String, Vec<SuggestContextQuery>>,
+    contexts: Map<String, Vec<SuggestContextQuery>>,
 }
 
 impl Suggester {

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,5 @@
+/// Map type alias for the whole library
+pub type Map<K, V> = std::collections::BTreeMap<K, V>;
+
+/// Set type alias for the whole library
+pub type Set<T> = std::collections::BTreeSet<T>;

--- a/src/util/should_skip.rs
+++ b/src/util/should_skip.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use crate::{Map, Set};
 
 /// Trait to handle skippable queries or their values
 pub(crate) trait ShouldSkip {
@@ -49,25 +49,13 @@ impl<T> ShouldSkip for Vec<T> {
     }
 }
 
-impl<T> ShouldSkip for HashSet<T> {
+impl<T> ShouldSkip for Set<T> {
     fn should_skip(&self) -> bool {
         self.is_empty()
     }
 }
 
-impl<T> ShouldSkip for &HashSet<T> {
-    fn should_skip(&self) -> bool {
-        self.is_empty()
-    }
-}
-
-impl<T> ShouldSkip for BTreeSet<T> {
-    fn should_skip(&self) -> bool {
-        self.is_empty()
-    }
-}
-
-impl<T> ShouldSkip for &BTreeSet<T> {
+impl<T> ShouldSkip for &Set<T> {
     fn should_skip(&self) -> bool {
         self.is_empty()
     }
@@ -79,25 +67,13 @@ impl<T> ShouldSkip for &[T] {
     }
 }
 
-impl<K, V> ShouldSkip for HashMap<K, V> {
+impl<K, V> ShouldSkip for Map<K, V> {
     fn should_skip(&self) -> bool {
         self.is_empty()
     }
 }
 
-impl<K, V> ShouldSkip for &HashMap<K, V> {
-    fn should_skip(&self) -> bool {
-        self.is_empty()
-    }
-}
-
-impl<K, V> ShouldSkip for BTreeMap<K, V> {
-    fn should_skip(&self) -> bool {
-        self.is_empty()
-    }
-}
-
-impl<K, V> ShouldSkip for &BTreeMap<K, V> {
+impl<K, V> ShouldSkip for &Map<K, V> {
     fn should_skip(&self) -> bool {
         self.is_empty()
     }


### PR DESCRIPTION
There was a mix of hashmaps and btreemaps in the lib, adding Set/Map alias for consistent and simplified usage.