### PR TITLE
Bump to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.3.9"
-authors = ["Boost <boost@vinted.com>"]
+version = "0.4.0"
+authors = ["Evaldas Buinauskas <evaldas.buinauskas@vinted.com>", "Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"
 repository = "https://github.com/vinted/elasticsearch-dsl-rs"


### PR DESCRIPTION
A large release with lots of cleanup:
- Relaxed query construction, terms queries now accept anything that's serializable, this won't require creating custom From<T> For Term conversions
- Support for all types of sorting criteria
- Support for completions
- Improved search responses with delayed parsing
- Correct inner hits support
- And much more.

