### PR TITLE
Improve CI builds

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,47 +6,16 @@ on:
 name: Rust
 
 jobs:
-  check:
-    name: Check
+  ci:
+    name: CI Build
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-
-  test:
-    name: Test Suite
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v2
-
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-  lints:
-    name: Lints
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features: [--all-features]
+      fail-fast: false
+    env:
+      RUSTFLAGS: -D warnings
+      CARGO_TERM_COLOR: always
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -58,6 +27,31 @@ jobs:
           toolchain: stable
           override: true
           components: rustfmt, clippy
+
+      - name: Install nextest
+        uses: taiki-e/install-action@v1
+        with:
+          tool: nextest
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.0.0
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+
+      - name: Run library tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: nextest
+          args: run ${{ matrix.features }}
+
+      - name: Run doc tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --doc
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1

--- a/src/search/response/search_response.rs
+++ b/src/search/response/search_response.rs
@@ -9,7 +9,7 @@ pub struct SearchResponse {
     /// The time that it took Elasticsearch to process the query
     pub took: u32,
 
-    /// Indicates whether there have been timed-out shards, if `true` - responses are partial
+    /// The search has been cancelled and results are partial
     pub timed_out: bool,
 
     /// Indicates if search has been terminated early


### PR DESCRIPTION
This switches to nextest runner and will run ci build in a single workflow instead of multiple parallel ones, this will be cheaper.