### PR TITLE
Tweak response struct

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.4.4"
+version = "0.4.7"
 authors = ["Evaldas Buinauskas <evaldas.buinauskas@vinted.com>", "Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/src/search/response/hit.rs
+++ b/src/search/response/hit.rs
@@ -14,11 +14,19 @@ pub struct Hit {
     pub explanation: Option<Explanation>,
 
     /// Document index
-    #[serde(skip_serializing_if = "ShouldSkip::should_skip", rename = "_index")]
-    pub index: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "ShouldSkip::should_skip",
+        rename = "_index"
+    )]
+    pub index: String,
 
     /// Document ID
-    #[serde(rename = "_id")]
+    #[serde(
+        default,
+        skip_serializing_if = "ShouldSkip::should_skip",
+        rename = "_id"
+    )]
     pub id: String,
 
     /// Document score. [`None`] when documents are implicitly sorted by a

--- a/src/search/response/search_response.rs
+++ b/src/search/response/search_response.rs
@@ -182,7 +182,7 @@ mod tests {
                 hits: vec![Hit {
                     explanation: None,
                     nested: None,
-                    index: Some("_index".into()),
+                    index: "_index".into(),
                     id: "123".into(),
                     score: Some(1.0),
                     source: Source::from_string("null".to_string()).unwrap(),


### PR DESCRIPTION
Makes index/id as strings with default "empty" values.