### PR TITLE
Update docs for ExecutionHint enum

### DIFF
--- a/src/search/aggregations/bucket/diversified_sampler_aggregation.rs
+++ b/src/search/aggregations/bucket/diversified_sampler_aggregation.rs
@@ -21,10 +21,10 @@ pub enum ExecutionHint {
     /// Hold field values directly
     Map,
 
-    /// Hold ordinals of the field as determined by the Lucene index
+    /// Hold hashes of the field values - with potential for hash collisions
     BytesHash,
 
-    /// Hold hashes of the field values - with potential for hash collisions
+    /// Hold ordinals of the field as determined by the Lucene index
     GlobalOrdinals,
 }
 


### PR DESCRIPTION
I swapped the comments for two variants to correctly match the official Elasticsearch documentation.

See latest documentation for [execution_hint in diversified sampler aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-diversified-sampler-aggregation.html#_execution_hint).