### PR TITLE
Fix stored fields _none_ case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.4.11"
+version = "0.4.12"
 authors = ["Evaldas Buinauskas <evaldas.buinauskas@vinted.com>", "Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@
     warnings,
     while_true
 )]
+#![allow(ambiguous_glob_reexports)]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/search/queries/params/mod.rs
+++ b/src/search/queries/params/mod.rs
@@ -8,6 +8,7 @@ mod negative_boost;
 mod operator;
 mod rewrite;
 mod script_object;
+mod stored_fields;
 mod zero_terms_query;
 
 // Query specific parameters
@@ -40,6 +41,7 @@ pub use self::rewrite::*;
 pub use self::script_object::*;
 pub use self::shape_query::*;
 pub use self::simple_query_string_query::*;
+pub use self::stored_fields::*;
 pub use self::terms_set_query::*;
 pub use self::text_query_type::*;
 pub use self::zero_terms_query::*;

--- a/src/search/queries/params/stored_fields.rs
+++ b/src/search/queries/params/stored_fields.rs
@@ -1,0 +1,78 @@
+use serde::Serialize;
+
+use crate::{types::Set, util::ShouldSkip};
+
+/// It’s also possible to store an individual field’s values by using the store mapping option.
+///
+/// <https://www.elastic.co/guide/en/elasticsearch/reference/8.8/search-fields.html#stored-fields>
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoredFields {
+    /// To disable the stored fields (and metadata fields) entirely use: `_none_`
+    None,
+
+    /// Allows to selectively load specific stored fields for each document represented by a search hit.
+    Fields(Set<String>),
+}
+
+impl Default for StoredFields {
+    fn default() -> Self {
+        Self::Fields(Set::default())
+    }
+}
+
+impl ShouldSkip for StoredFields {
+    fn should_skip(&self) -> bool {
+        match self {
+            Self::None => false,
+            Self::Fields(fields) => fields.should_skip(),
+        }
+    }
+}
+
+impl Serialize for StoredFields {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::None => serializer.serialize_str("_none_"),
+            Self::Fields(fields) => fields.serialize(serializer),
+        }
+    }
+}
+
+impl<T> From<T> for StoredFields
+where
+    T: IntoIterator,
+    T::Item: ToString,
+{
+    fn from(value: T) -> Self {
+        let fields = value.into_iter().map(|v| v.to_string()).collect::<Set<_>>();
+
+        if fields.len() == 1 && fields.contains("_none_") {
+            Self::None
+        } else {
+            Self::Fields(fields)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::assert_serialize;
+
+    #[test]
+    fn serialization() {
+        assert_serialize(StoredFields::None, json!("_none_"));
+        assert_serialize(StoredFields::from(["_none_"]), json!("_none_"));
+        assert_serialize(StoredFields::from(["abc", "def"]), json!(["abc", "def"]));
+    }
+
+    #[test]
+    fn should_skip() {
+        assert!(!StoredFields::None.should_skip());
+        assert!(!StoredFields::from(["abc", "def"]).should_skip());
+        assert!(StoredFields::from(Vec::<String>::new()).should_skip());
+    }
+}

--- a/src/search/queries/specialized/more_like_this_query.rs
+++ b/src/search/queries/specialized/more_like_this_query.rs
@@ -1,6 +1,5 @@
 use crate::search::*;
 use crate::util::*;
-use crate::Set;
 
 /// The More Like This Query finds documents that are "like" a given set of documents.
 /// In order to do so, MLT selects a set of representative terms of these input documents,
@@ -147,7 +146,7 @@ pub struct Document {
     _source: Option<SourceFilter>,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    _stored_fields: Set<String>,
+    _stored_fields: StoredFields,
 }
 
 impl Document {
@@ -160,7 +159,7 @@ impl Document {
     {
         Self {
             _id: id.to_string(),
-            _stored_fields: Set::new(),
+            _stored_fields: Default::default(),
             _index: None,
             _routing: None,
             _source: None,
@@ -197,10 +196,9 @@ impl Document {
     /// The stored fields you want to retrieve.
     pub fn stored_fields<T>(mut self, stored_fields: T) -> Self
     where
-        T: IntoIterator,
-        T::Item: ToString,
+        T: Into<StoredFields>,
     {
-        self._stored_fields = stored_fields.into_iter().map(|x| x.to_string()).collect();
+        self._stored_fields = stored_fields.into();
         self
     }
 }

--- a/src/search/request.rs
+++ b/src/search/request.rs
@@ -52,7 +52,7 @@ pub struct Search {
     suggest: Map<String, Suggester>,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
-    stored_fields: Set<String>,
+    stored_fields: StoredFields,
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     docvalue_fields: Set<String>,
@@ -195,11 +195,9 @@ impl Search {
     /// A collection of stored fields
     pub fn stored_fields<T>(mut self, stored_fields: T) -> Self
     where
-        T: IntoIterator,
-        T::Item: ToString,
+        T: Into<StoredFields>,
     {
-        self.stored_fields
-            .extend(stored_fields.into_iter().map(|x| x.to_string()));
+        self.stored_fields = stored_fields.into();
         self
     }
 


### PR DESCRIPTION
One of the upgrades broker Elasticsearch internals, which no longer accept `["_none_"]` as a valid docvalue field, it explicitly expects `"_none_"` - a single string value.

Handle this by introducing a `StoredFields` enum which will contain the exact None case and regular fields. This should be a non-breaking change because a collection of single _none_ item will be serialized as _none_ string.