### PR TITLE
Implement post filter

### DIFF
--- a/src/search/request.rs
+++ b/src/search/request.rs
@@ -56,6 +56,9 @@ pub struct Search {
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     docvalue_fields: Set<String>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    post_filter: Option<Query>,
 }
 
 impl Search {
@@ -141,6 +144,16 @@ impl Search {
         Q: Into<Query>,
     {
         self.query = Some(query.into());
+        self
+    }
+
+    /// When you use the `post_filter` parameter to filter search results, the search hits are filtered after the
+    /// aggregations are calculated. A post filter has no impact on the aggregation results.
+    pub fn post_filter<Q>(mut self, post_filter: Q) -> Self
+    where
+        Q: Into<Query>,
+    {
+        self.post_filter = Some(post_filter.into());
         self
     }
 

--- a/src/util/assert_serialize.rs
+++ b/src/util/assert_serialize.rs
@@ -17,10 +17,13 @@ where
 #[cfg(test)]
 pub(crate) fn assert_serialize_query<T>(subject: T, expectation: serde_json::Value)
 where
-    T: Into<crate::Query>,
+    T: Into<crate::Query> + Clone,
 {
-    let subject = crate::Search::new().query(subject);
-    let expectation = json!({ "query": expectation });
+    let subject = crate::Search::new()
+        .query(subject.clone())
+        .post_filter(subject);
+
+    let expectation = json!({ "query": expectation, "post_filter": expectation });
 
     assert_serialize(subject, expectation)
 }


### PR DESCRIPTION
Post filter is a regular query executed after aggregation phase. Solves https://github.com/vinted/elasticsearch-dsl-rs/issues/218.

