### PR TITLE
Renaming scroll_id to _scroll_id.

### DIFF
--- a/src/search/response/search_response.rs
+++ b/src/search/response/search_response.rs
@@ -18,6 +18,7 @@ pub struct SearchResponse {
 
     /// Scroll Id
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    #[serde(rename = "_scroll_id")]
     pub scroll_id: Option<String>,
 
     /// Dynamically fetched fields


### PR DESCRIPTION
The scroll id is returned as `_scroll_id` in the elasticsearch JSON payload.

See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-search.html#search-api-response-body