### PR TITLE
Bump version to 0.4.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.4.14"
+version = "0.4.15"
 authors = ["Evaldas Buinauskas <evaldas.buinauskas@vinted.com>", "Boost <boost@vinted.com>"]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"


### PR DESCRIPTION
Releases https://github.com/vinted/elasticsearch-dsl-rs/pull/222.