### PR TITLE
Add support for `search_after` request API

### DIFF
--- a/src/search/params/terms.rs
+++ b/src/search/params/terms.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::util::*;
 
 /// A collection of terms
-#[derive(Clone, PartialEq, Serialize)]
+#[derive(Clone, PartialEq, Serialize, Default)]
 pub struct Terms(Vec<Term>);
 
 impl std::fmt::Debug for Terms {

--- a/src/search/request.rs
+++ b/src/search/request.rs
@@ -62,6 +62,9 @@ pub struct Search {
 
     #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
     post_filter: Option<Query>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    search_after: Terms,
 }
 
 impl Search {
@@ -235,6 +238,15 @@ impl Search {
     {
         self.docvalue_fields
             .extend(docvalue_fields.into_iter().map(|x| x.to_string()));
+        self
+    }
+
+    /// Search after a set of sort values.
+    pub fn search_after<T>(mut self, sort_values: T) -> Self
+    where
+        T: Into<Terms>,
+    {
+        self.search_after = sort_values.into();
         self
     }
 


### PR DESCRIPTION
Hi, thanks for maintaining this great library!

https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#search-after