### PR TITLE
Bump version to 0.4.16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "elasticsearch-dsl"
-version = "0.4.15"
-authors = ["Evaldas Buinauskas <evaldas.buinauskas@vinted.com>", "Boost <boost@vinted.com>"]
+version = "0.4.16"
+authors = [
+    "Evaldas Buinauskas <evaldas.buinauskas@vinted.com>",
+    "Boost <boost@vinted.com>",
+]
 edition = "2018"
 description = "Strongly typed Elasticsearch DSL"
 repository = "https://github.com/vinted/elasticsearch-dsl-rs"
@@ -12,7 +15,10 @@ license = "MIT OR Apache-2.0"
 members = ["examples/*"]
 
 [dependencies]
-chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "std",
+    "serde",
+] }
 num-traits = { version = "0.2" }
 serde = { version = "1", default-features = false, features = ["derive"] }
 serde_json = { version = "1", features = ["raw_value"] }


### PR DESCRIPTION
Releases https://github.com/vinted/elasticsearch-dsl-rs/pull/226.