### PR TITLE
Support f32 and f64 in decay functions

### DIFF
--- a/src/search/queries/params/function_score_query.rs
+++ b/src/search/queries/params/function_score_query.rs
@@ -108,6 +108,8 @@ function!(Function {
     DecayU16(Decay<u16>),
     DecayU32(Decay<u32>),
     DecayU64(Decay<u64>),
+    DecayF32(Decay<f32>),
+    DecayF64(Decay<f64>),
     ScriptScore(ScriptScore),
 });
 
@@ -687,6 +689,21 @@ mod tests {
                 "script_score": {
                     "script": {
                         "source": "Math.log(2 + doc['my-int'].value)"
+                    }
+                }
+            }),
+        );
+    }
+
+    #[test]
+    fn float_decay() {
+        assert_serialize(
+            Decay::new(DecayFunction::Linear, "test", 0.1, 0.5),
+            json!({
+                "linear": {
+                    "test": {
+                        "origin": 0.1,
+                        "scale": 0.5
                     }
                 }
             }),


### PR DESCRIPTION
Looks like f32 and f64 were missed from the `Function` macro defined [here](https://github.com/vinted/elasticsearch-dsl-rs/blob/master/src/search/queries/params/function_score_query.rs#L97-L112)

This pr adds the missing float types to the list and adds a test to ensure it is serialised correctly

docs: [function score query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#:~:text=must%20be%20a-,numeric,-%2C%20date%2C%20or%20geopoint) supports all [numeric field types](https://www.elastic.co/guide/en/elasticsearch/reference/current/number.html)