### PR TITLE
chore: fix clippy lints

### DIFF
--- a/src/search/aggregations/bucket/date_histogram_aggregation.rs
+++ b/src/search/aggregations/bucket/date_histogram_aggregation.rs
@@ -123,14 +123,14 @@ impl DateHistogramAggregation {
     /// Order field allows changing this behavior.
     ///
     /// > Sorting by ascending `_count` or by sub aggregation is discouraged as it increases the
-    /// [error](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-approximate-counts)
-    /// on document counts. It is fine when a single shard is queried, or when the field that is
-    /// being aggregated was used as a routing key at index time: in these cases results will be
-    /// accurate since shards have disjoint values. However otherwise, errors are unbounded.
-    /// One particular case that could still be useful is sorting by
-    /// [min](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html) or
-    /// [max](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html)
-    /// aggregation: counts will not be accurate but at least the top buckets will be correctly picked.
+    /// > [error](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-approximate-counts)
+    /// > on document counts. It is fine when a single shard is queried, or when the field that is
+    /// > being aggregated was used as a routing key at index time: in these cases results will be
+    /// > accurate since shards have disjoint values. However otherwise, errors are unbounded.
+    /// > One particular case that could still be useful is sorting by
+    /// > [min](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html) or
+    /// > [max](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html)
+    /// > aggregation: counts will not be accurate but at least the top buckets will be correctly picked.
     pub fn order<T>(mut self, order: T) -> Self
     where
         T: Into<TermsOrderCollection>,

--- a/src/search/aggregations/bucket/mod.rs
+++ b/src/search/aggregations/bucket/mod.rs
@@ -13,9 +13,9 @@
 //! and others dynamically create the buckets during the aggregation process.
 //!
 //! > The maximum number of buckets allowed in a single response is limited by
-//! a dynamic cluster setting named
-//! [`search.max_buckets`](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-settings.html#search-settings-max-buckets).
-//! It defaults to `65,535`. Requests that try to return more than the limit will fail with an exception.
+//! > a dynamic cluster setting named
+//! > [`search.max_buckets`](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-settings.html#search-settings-max-buckets).
+//! > It defaults to `65,535`. Requests that try to return more than the limit will fail with an exception.
 //!
 //! <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket.html>
 

--- a/src/search/aggregations/bucket/terms_aggregation.rs
+++ b/src/search/aggregations/bucket/terms_aggregation.rs
@@ -89,14 +89,14 @@ impl TermsAggregation {
     /// Order field allows changing this behavior.
     ///
     /// > Sorting by ascending `_count` or by sub aggregation is discouraged as it increases the
-    /// [error](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-approximate-counts)
-    /// on document counts. It is fine when a single shard is queried, or when the field that is
-    /// being aggregated was used as a routing key at index time: in these cases results will be
-    /// accurate since shards have disjoint values. However otherwise, errors are unbounded.
-    /// One particular case that could still be useful is sorting by
-    /// [min](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html) or
-    /// [max](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html)
-    /// aggregation: counts will not be accurate but at least the top buckets will be correctly picked.
+    /// > [error](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#search-aggregations-bucket-terms-aggregation-approximate-counts)
+    /// > on document counts. It is fine when a single shard is queried, or when the field that is
+    /// > being aggregated was used as a routing key at index time: in these cases results will be
+    /// > accurate since shards have disjoint values. However otherwise, errors are unbounded.
+    /// > One particular case that could still be useful is sorting by
+    /// > [min](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html) or
+    /// > [max](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html)
+    /// > aggregation: counts will not be accurate but at least the top buckets will be correctly picked.
     pub fn order<T>(mut self, order: T) -> Self
     where
         T: Into<TermsOrderCollection>,

--- a/src/search/aggregations/metrics/boxplot_aggregation.rs
+++ b/src/search/aggregations/metrics/boxplot_aggregation.rs
@@ -12,7 +12,7 @@ use crate::{Aggregation, Number};
 /// [Computing Accurate Quantiles using T-Digests](https://github.com/tdunning/t-digest/blob/master/docs/t-digest-paper/histo.pdf)).
 ///
 /// > Boxplot as other percentile aggregations are also [non-deterministic](https://en.wikipedia.org/wiki/Nondeterministic_algorithm).
-/// This means you can get slightly different results using the same data.
+/// > This means you can get slightly different results using the same data.
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-boxplot-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]

--- a/src/search/aggregations/metrics/max_aggregation.rs
+++ b/src/search/aggregations/metrics/max_aggregation.rs
@@ -5,8 +5,8 @@ use crate::util::*;
 /// numeric values extracted from the aggregated documents.
 ///
 /// > The `min` and `max` aggregation operate on the `double` representation of the data. As a
-/// consequence, the result may be approximate when running on longs whose absolute value is greater
-/// than `2^53`.
+/// > consequence, the result may be approximate when running on longs whose absolute value is greater
+/// > than `2^53`.
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-max-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]

--- a/src/search/aggregations/metrics/min_aggregation.rs
+++ b/src/search/aggregations/metrics/min_aggregation.rs
@@ -5,8 +5,8 @@ use crate::util::*;
 /// values extracted from the aggregated documents.
 ///
 /// > The `min` and `max` aggregation operate on the `double` representation of the data. As a
-/// consequence, the result may be approximate when running on longs whose absolute value is greater
-/// than `2^53`.
+/// > consequence, the result may be approximate when running on longs whose absolute value is greater
+/// > than `2^53`.
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-min-aggregation.html>
 #[derive(Debug, Clone, Serialize, PartialEq)]

--- a/src/search/aggregations/metrics/top_hits_aggregation.rs
+++ b/src/search/aggregations/metrics/top_hits_aggregation.rs
@@ -6,9 +6,9 @@ use crate::util::*;
 /// so that the top matching documents can be aggregated per bucket.
 ///
 /// > We do not recommend using `top_hits` as a top-level aggregation.
-/// If you want to group search hits, use the
-/// [`collapse`](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html)
-/// parameter instead.
+/// > If you want to group search hits, use the
+/// > [`collapse`](https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html)
+/// > parameter instead.
 ///
 /// The `top_hits` aggregation can effectively be used to group result sets
 /// by certain fields via a bucket aggregation. One or more bucket aggregations

--- a/src/search/aggregations/pipeline/mod.rs
+++ b/src/search/aggregations/pipeline/mod.rs
@@ -4,11 +4,11 @@
 //!
 //! **Parent**
 //! > A family of pipeline aggregations that is provided with the output of its parent aggregation and is able
-//! to compute new buckets or new aggregations to add to existing buckets.
+//! > to compute new buckets or new aggregations to add to existing buckets.
 //!
 //! **Sibling**
 //! > Pipeline aggregations that are provided with the output of a sibling aggregation and are able to compute a
-//! new aggregation which will be at the same level as the sibling aggregation.
+//! > new aggregation which will be at the same level as the sibling aggregation.
 //!
 //! Pipeline aggregations can reference the aggregations they need to perform their computation by using the `buckets_path`
 //! parameter to indicate the paths to the required metrics. The syntax for defining these paths can be found in the
@@ -19,7 +19,7 @@
 //! (i.e. a derivative of a derivative).
 //!
 //! > **NOTE**: Because pipeline aggregations only add to the output, when chaining pipeline aggregations the output of each pipeline aggregation
-//! will be included in the final output.
+//! > will be included in the final output.
 //!
 //! <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-pipeline.html>
 

--- a/src/search/highlight/boundary_scanner.rs
+++ b/src/search/highlight/boundary_scanner.rs
@@ -10,8 +10,8 @@ pub enum UnifiedBoundaryScanner {
     ///
     /// > **Warning**<br/>
     /// > The `sentence` scanner splits sentences bigger than `fragment_size` at the first word
-    /// boundary next to `fragment_size`. You can set `fragment_size` to 0 to never split any
-    /// sentence.
+    /// > boundary next to `fragment_size`. You can set `fragment_size` to 0 to never split any
+    /// > sentence.
     Sentence(Option<String>),
 
     /// Break highlighted fragments at the next word boundary, as determined by Java’s

--- a/src/search/highlight/highlighter.rs
+++ b/src/search/highlight/highlighter.rs
@@ -66,18 +66,18 @@ pub struct DefaultHighlighter {
 /// highlighter:
 ///
 /// - Can be customized with a
-/// [boundary_scanner](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#boundary-scanners).
+///   [boundary_scanner](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#boundary-scanners).
 /// - Requires setting `term_vector` to `with_positions_offsets` which increases the size of the
-/// index
+///   index
 /// - Can combine matches from multiple fields into one result. See
-/// [`matched_fields`](FastVectorHighlighter::matched_fields)
+///   [`matched_fields`](FastVectorHighlighter::matched_fields)
 /// - Can assign different weights to matches at different positions allowing for things like
-/// phrase matches being sorted above term matches when highlighting a Boosting Query that boosts
-/// phrase matches over term matches
+///   phrase matches being sorted above term matches when highlighting a Boosting Query that boosts
+///   phrase matches over term matches
 ///
 /// > **Warning**<br/>
 /// > The `fvh` highlighter does not support span queries. If you need support for span queries,
-/// try an alternative highlighter, such as the `unified` highlighter.
+/// > try an alternative highlighter, such as the `unified` highlighter.
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#fast-vector-highlighter>
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -144,12 +144,12 @@ pub struct FastVectorHighlighter {
 ///
 /// > **Warning**<br/>
 /// > The `plain` highlighter works best for highlighting simple query matches in a single field.
-/// To accurately reflect query logic, it creates a tiny in-memory index and re-runs the original
-/// query criteria through Lucene’s query execution planner to get access to low-level match
-/// information for the current document. This is repeated for every field and every document that
-/// needs to be highlighted. If you want to highlight a lot of fields in a lot of documents with
-/// complex queries, we recommend using the `unified` highlighter on `postings` or `term_vector`
-/// fields.
+/// > To accurately reflect query logic, it creates a tiny in-memory index and re-runs the original
+/// > query criteria through Lucene’s query execution planner to get access to low-level match
+/// > information for the current document. This is repeated for every field and every document that
+/// > needs to be highlighted. If you want to highlight a lot of fields in a lot of documents with
+/// > complex queries, we recommend using the `unified` highlighter on `postings` or `term_vector`
+/// > fields.
 ///
 /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#plain-highlighter>
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -419,8 +419,8 @@ macro_rules! add_highlighter_methods {
         ///
         /// > **Warning**<br/>
         /// > Elasticsearch does not validate that `highlight_query` contains the search query in any
-        /// way so it is possible to define it so legitimate query results are not highlighted.
-        /// Generally, you should include the search query as part of the `highlight_query`.
+        /// > way so it is possible to define it so legitimate query results are not highlighted.
+        /// > Generally, you should include the search query as part of the `highlight_query`.
         pub fn highlight_query<T>(mut self, highlight_query: T) -> Self
         where
             T: Into<Query>,

--- a/src/search/highlight/mod.rs
+++ b/src/search/highlight/mod.rs
@@ -12,28 +12,28 @@
 //! be obtained from:
 //!
 //! - The postings list. If `index_options` is set to `offsets` in the mapping, the
-//! [`unified` highlighter](UnifiedHighlighter) uses this information to highlight documents
-//! without re-analyzing the text. It re-runs the original query directly on the postings and
-//! extracts the matching offsets from the index, limiting the collection to the highlighted
-//! documents. This is important if you have large fields because it doesn’t require reanalyzing
-//! the text to be highlighted. It also requires less disk space than using `term_vectors`.
+//!   [`unified` highlighter](UnifiedHighlighter) uses this information to highlight documents
+//!   without re-analyzing the text. It re-runs the original query directly on the postings and
+//!   extracts the matching offsets from the index, limiting the collection to the highlighted
+//!   documents. This is important if you have large fields because it doesn’t require reanalyzing
+//!   the text to be highlighted. It also requires less disk space than using `term_vectors`.
 //! - Term vectors. If `term_vector` information is provided by setting `term_vector` to
-//! `with_positions_offsets` in the mapping, the [`unified` highlighter](UnifiedHighlighter)
-//! automatically uses the `term_vector` to highlight the field. It’s fast especially for large
-//! fields (> `1MB`) and for highlighting multi-term queries like `prefix` or `wildcard` because it
-//! can access the dictionary of terms for each document. The
-//! [`fvh` highlighter](FastVectorHighlighter) always uses term vectors.
+//!   `with_positions_offsets` in the mapping, the [`unified` highlighter](UnifiedHighlighter)
+//!   automatically uses the `term_vector` to highlight the field. It’s fast especially for large
+//!   fields (> `1MB`) and for highlighting multi-term queries like `prefix` or `wildcard` because it
+//!   can access the dictionary of terms for each document. The
+//!   [`fvh` highlighter](FastVectorHighlighter) always uses term vectors.
 //! - Plain highlighting. This mode is used by the [`unified`](UnifiedHighlighter) when there is no
-//! other alternative. It creates a tiny in-memory index and re-runs the original query criteria
-//! through Lucene’s query execution planner to get access to low-level match information on the
-//! current document. This is repeated for every field and every document that needs highlighting.
-//! The [`plain` highlighter](PlainHighlighter) always uses plain highlighting.
+//!   other alternative. It creates a tiny in-memory index and re-runs the original query criteria
+//!   through Lucene’s query execution planner to get access to low-level match information on the
+//!   current document. This is repeated for every field and every document that needs highlighting.
+//!   The [`plain` highlighter](PlainHighlighter) always uses plain highlighting.
 //!
 //! > **Warning**<br/>
 //! > Plain highlighting for large texts may require substantial amount of time and memory. To
-//! protect against this, the maximum number of text characters that will be analyzed has been
-//! limited to 1000000. This default limit can be changed for a particular index with the index
-//! setting `index.highlight.max_analyzed_offset`.
+//! > protect against this, the maximum number of text characters that will be analyzed has been
+//! > limited to 1000000. This default limit can be changed for a particular index with the index
+//! > setting `index.highlight.max_analyzed_offset`.
 //!
 //! <https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html>
 

--- a/src/search/knn/mod.rs
+++ b/src/search/knn/mod.rs
@@ -66,7 +66,7 @@ impl Knn {
     ///
     /// - `field` - The name of the vector field to search against. Must be a dense_vector field with indexing enabled.
     /// - `query_vector` - Query vector. Must have the same number of dimensions as the vector field you are searching
-    /// against.
+    ///   against.
     pub fn query_vector<T>(field: T, query_vector: Vec<f32>) -> Self
     where
         T: ToString,
@@ -174,8 +174,8 @@ impl From<TextEmbedding> for QueryVectorBuilder {
 impl TextEmbedding {
     /// Creates an instance of [`TextEmbedding`]
     /// - `model_id` - The ID of the text embedding model to use to generate the dense vectors from the query string.
-    /// Use the same model that generated the embeddings from the input text in the index you search against. You can
-    /// use the value of the deployment_id instead in the model_id argument.
+    ///   Use the same model that generated the embeddings from the input text in the index you search against. You can
+    ///   use the value of the deployment_id instead in the model_id argument.
     /// - `model_text` - The query string from which the model generates the dense vector representation.
     pub fn new<T, U>(model_id: T, model_text: U) -> Self
     where

--- a/src/search/queries/compound/boosting_query.rs
+++ b/src/search/queries/compound/boosting_query.rs
@@ -38,17 +38,17 @@ impl Query {
     ///
     /// - `positive` - Query you wish to run. Any returned documents must match this query.
     /// - `negative` - Query used to decrease the
-    /// [relevance score](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores)
-    /// of matching documents.<br/>
-    /// If a returned document matches the `positive` query and this query, the `boosting` query
-    /// calculates the final
-    /// [relevance score](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores)
-    /// for the document as follows:
+    ///   [relevance score](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores)
+    ///   of matching documents.<br/>
+    ///   If a returned document matches the `positive` query and this query, the `boosting` query
+    ///   calculates the final
+    ///   [relevance score](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores)
+    ///   for the document as follows:
     ///     1. Take the original relevance score from the `positive` query.
     ///     2. Multiply the score by the `negative_boost` value.
     /// - `negative_boost` - Floating point number between `0` and `1.0` used to decrease the
-    /// [relevance scores](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores)
-    /// of documents matching the `negative` query.
+    ///   [relevance scores](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores)
+    ///   of documents matching the `negative` query.
     pub fn boosting<Q, B>(positive: Q, negative: Q, negative_boost: B) -> BoostingQuery
     where
         Q: Into<Query>,

--- a/src/search/queries/compound/constant_score_query.rs
+++ b/src/search/queries/compound/constant_score_query.rs
@@ -32,10 +32,10 @@ impl Query {
     /// Creates an instance of [`ConstantScoreQuery`]
     ///
     /// - `filter` - [Filter query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html)
-    /// you wish to run. Any returned documents must match this query.<br/>
-    /// Filter queries do not calculate
-    /// [relevance scores](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores).
-    /// To speed up performance, Elasticsearch automatically caches frequently used filter queries.
+    ///   you wish to run. Any returned documents must match this query.<br/>
+    ///   Filter queries do not calculate
+    ///   [relevance scores](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-filter-context.html#relevance-scores).
+    ///   To speed up performance, Elasticsearch automatically caches frequently used filter queries.
     pub fn constant_score<T>(filter: T) -> ConstantScoreQuery
     where
         T: Into<Query>,

--- a/src/search/queries/full_text/combined_fields_query.rs
+++ b/src/search/queries/full_text/combined_fields_query.rs
@@ -49,10 +49,10 @@ impl Query {
     /// Creates an instance of [`CombinedFieldsQuery`]
     ///
     /// - `fields` - List of fields to search. Field wildcard patterns are
-    /// allowed. Only text fields are supported, and they must all have the
-    /// same search analyzer.
+    ///   allowed. Only text fields are supported, and they must all have the
+    ///   same search analyzer.
     /// - `query` - Text to search for in the provided `<fields>`.
-    /// The combined_fields query analyzes the provided text before performing a search.
+    ///   The combined_fields query analyzes the provided text before performing a search.
     pub fn combined_fields<F, S>(fields: F, query: S) -> CombinedFieldsQuery
     where
         F: IntoIterator,

--- a/src/search/queries/full_text/match_phrase_prefix_query.rs
+++ b/src/search/queries/full_text/match_phrase_prefix_query.rs
@@ -48,9 +48,9 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `query` - Text you wish to find in the provided `<field>`. <br/> The `match_phrase_prefix`
-    /// query analyzes any provided text into tokens before performing a search. The last term of
-    /// this text is treated as a [prefix](crate::PrefixQuery), matching any words that begin with
-    /// that term.
+    ///   query analyzes any provided text into tokens before performing a search. The last term of
+    ///   this text is treated as a [prefix](crate::PrefixQuery), matching any words that begin with
+    ///   that term.
     pub fn match_phrase_prefix<T, U>(field: T, query: U) -> MatchPhrasePrefixQuery
     where
         T: ToString,

--- a/src/search/queries/full_text/match_phrase_query.rs
+++ b/src/search/queries/full_text/match_phrase_query.rs
@@ -41,13 +41,13 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `query` - Text, number, boolean value or date you wish to find in the provided
-    /// `<field>`.<br/>
-    /// The `match_phrase` query
-    /// [analyzes](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html)
-    /// any provided text before performing a search. This means the
-    /// `match_phrase` query can search
-    /// [`text`](https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html)
-    /// fields for analyzed tokens rather than an exact term.
+    ///   `<field>`.<br/>
+    ///   The `match_phrase` query
+    ///   [analyzes](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html)
+    ///   any provided text before performing a search. This means the
+    ///   `match_phrase` query can search
+    ///   [`text`](https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html)
+    ///   fields for analyzed tokens rather than an exact term.
     pub fn match_phrase<T, U>(field: T, query: U) -> MatchPhraseQuery
     where
         T: ToString,

--- a/src/search/queries/full_text/match_query.rs
+++ b/src/search/queries/full_text/match_query.rs
@@ -71,13 +71,13 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `query` - Text, number, boolean value or date you wish to find in the provided
-    /// `<field>`.<br/>
-    /// The `match` query
-    /// [analyzes](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html)
-    /// any provided text before performing a search. This means the `match`
-    /// query can search
-    /// [`text`](https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html)
-    /// fields for analyzed tokens rather than an exact term.
+    ///   `<field>`.<br/>
+    ///   The `match` query
+    ///   [analyzes](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html)
+    ///   any provided text before performing a search. This means the `match`
+    ///   query can search
+    ///   [`text`](https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html)
+    ///   fields for analyzed tokens rather than an exact term.
     pub fn r#match<T, U>(field: T, query: U) -> MatchQuery
     where
         T: ToString,

--- a/src/search/queries/full_text/multi_match_query.rs
+++ b/src/search/queries/full_text/multi_match_query.rs
@@ -77,12 +77,12 @@ impl Query {
     ///
     /// - `fields` - Fields you wish to search.
     /// - `query` - Text, number, boolean value or date you wish to find in the provided
-    /// `<field>`. The `match` query
-    /// [analyzes](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html)
-    /// any provided text before performing a search. This means the `match`
-    /// query can search
-    /// [`text`](https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html)
-    /// fields for analyzed tokens rather than an exact term.
+    ///   `<field>`. The `match` query
+    ///   [analyzes](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis.html)
+    ///   any provided text before performing a search. This means the `match`
+    ///   query can search
+    ///   [`text`](https://www.elastic.co/guide/en/elasticsearch/reference/current/text.html)
+    ///   fields for analyzed tokens rather than an exact term.
     pub fn multi_match<F, S>(fields: F, query: S) -> MultiMatchQuery
     where
         F: IntoIterator,

--- a/src/search/queries/full_text/query_string_query.rs
+++ b/src/search/queries/full_text/query_string_query.rs
@@ -94,7 +94,7 @@ impl Query {
     /// Creates an instance of [`QueryStringQuery`]
     ///
     /// - `query` - Query string you wish to parse and use for search. See
-    /// [Simple query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax).
+    ///   [Simple query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax).
     pub fn query_string<S>(query: S) -> QueryStringQuery
     where
         S: Into<Text>,

--- a/src/search/queries/full_text/simple_query_string_query.rs
+++ b/src/search/queries/full_text/simple_query_string_query.rs
@@ -73,7 +73,7 @@ impl Query {
     /// Creates an instance of [`SimpleQueryStringQuery`]
     ///
     /// - `query` - Query string you wish to parse and use for search. See
-    /// [Simple query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax).
+    ///   [Simple query string syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html#simple-query-string-syntax).
     pub fn simple_query_string<S>(query: S) -> SimpleQueryStringQuery
     where
         S: Into<Text>,

--- a/src/search/queries/joining/has_child_query.rs
+++ b/src/search/queries/joining/has_child_query.rs
@@ -46,7 +46,7 @@ impl Query {
     ///
     /// - `type` - Name of the child relationship mapped for the join field.
     /// - `query` - Query you wish to run on child documents of the `type` field. If a child
-    /// document matches the search, the query returns the parent document.
+    ///   document matches the search, the query returns the parent document.
     pub fn has_child<T, U>(r#type: T, query: U) -> HasChildQuery
     where
         T: ToString,

--- a/src/search/queries/joining/has_parent_query.rs
+++ b/src/search/queries/joining/has_parent_query.rs
@@ -37,7 +37,7 @@ impl Query {
     ///
     /// - `parent-type` - Name of the parent relationship mapped for the join field.
     /// - `query` - Query you wish to run on parent documents of the `parent_type` field. If a
-    /// parent document matches the search, the query returns its child documents.
+    ///   parent document matches the search, the query returns its child documents.
     pub fn has_parent<T, U>(parent_type: T, query: U) -> HasParentQuery
     where
         T: ToString,

--- a/src/search/queries/joining/nested_query.rs
+++ b/src/search/queries/joining/nested_query.rs
@@ -56,14 +56,14 @@ impl Query {
     ///
     /// - `path` - Path to the nested object you wish to search.
     /// - `query` - Query you wish to run on nested objects in the `path`. If an object
-    /// matches the search, the `nested` query returns the root parent document.<br/>
-    /// You can search nested fields using dot notation that includes the
-    /// complete path, such as `obj1.name`.<br/>
-    /// Multi-level nesting is automatically supported, and detected,
-    /// resulting in an inner nested query to automatically match the relevant
-    /// nesting level, rather than root, if it exists within another nested
-    /// query.<br/>
-    /// Multi-level nested queries are also supported.
+    ///   matches the search, the `nested` query returns the root parent document.<br/>
+    ///   You can search nested fields using dot notation that includes the
+    ///   complete path, such as `obj1.name`.<br/>
+    ///   Multi-level nesting is automatically supported, and detected,
+    ///   resulting in an inner nested query to automatically match the relevant
+    ///   nesting level, rather than root, if it exists within another nested
+    ///   query.<br/>
+    ///   Multi-level nested queries are also supported.
     pub fn nested<T, U>(path: T, query: U) -> NestedQuery
     where
         T: ToString,

--- a/src/search/queries/joining/parent_id_query.rs
+++ b/src/search/queries/joining/parent_id_query.rs
@@ -34,7 +34,7 @@ impl Query {
     ///
     /// - `type` - Name of the child relationship mapped for the join field
     /// - `id` - ID of the parent document. The query will return child documents of this
-    /// parent document.
+    ///   parent document.
     pub fn parent_id<T, U>(r#type: T, id: U) -> ParentIdQuery
     where
         T: ToString,

--- a/src/search/queries/params/function_score_query.rs
+++ b/src/search/queries/params/function_score_query.rs
@@ -139,13 +139,13 @@ impl Function {
     /// - `function` - Decay function variant
     /// - `field` - Field to apply function to
     /// - `origin` - The point of origin used for calculating distance. Must be given as a number
-    /// for numeric field, date for date fields and geo point for geo fields. Required for geo and
-    /// numeric field. For date fields the default is `now`. Date math (for example now-1h) is
-    /// supported for origin.
+    ///   for numeric field, date for date fields and geo point for geo fields. Required for geo and
+    ///   numeric field. For date fields the default is `now`. Date math (for example now-1h) is
+    ///   supported for origin.
     /// - `scale` - Required for all types. Defines the distance from origin + offset at which the
-    /// computed score will equal `decay` parameter. For geo fields: Can be defined as number+unit
-    /// (1km, 12m,…​). Default unit is meters. For date fields: Can to be defined as a number+unit
-    /// ("1h", "10d",…​). Default unit is milliseconds. For numeric field: Any number.
+    ///   computed score will equal `decay` parameter. For geo fields: Can be defined as number+unit
+    ///   (1km, 12m,…​). Default unit is meters. For date fields: Can to be defined as a number+unit
+    ///   ("1h", "10d",…​). Default unit is milliseconds. For numeric field: Any number.
     pub fn decay<T, O>(
         function: DecayFunction,
         field: T,
@@ -509,13 +509,13 @@ where
     /// - `function` - Decay function variant
     /// - `field` - Field to apply function to
     /// - `origin` - The point of origin used for calculating distance. Must be given as a number
-    /// for numeric field, date for date fields and geo point for geo fields. Required for geo and
-    /// numeric field. For date fields the default is `now`. Date math (for example now-1h) is
-    /// supported for origin.
+    ///   for numeric field, date for date fields and geo point for geo fields. Required for geo and
+    ///   numeric field. For date fields the default is `now`. Date math (for example now-1h) is
+    ///   supported for origin.
     /// - `scale` - Required for all types. Defines the distance from origin + offset at which the
-    /// computed score will equal `decay` parameter. For geo fields: Can be defined as number+unit
-    /// (1km, 12m,…​). Default unit is meters. For date fields: Can to be defined as a number+unit
-    /// ("1h", "10d",…​). Default unit is milliseconds. For numeric field: Any number.
+    ///   computed score will equal `decay` parameter. For geo fields: Can be defined as number+unit
+    ///   (1km, 12m,…​). Default unit is meters. For date fields: Can to be defined as a number+unit
+    ///   ("1h", "10d",…​). Default unit is milliseconds. For numeric field: Any number.
     pub fn new<T>(function: DecayFunction, field: T, origin: O, scale: <O as Origin>::Scale) -> Self
     where
         T: ToString,

--- a/src/search/queries/params/rewrite.rs
+++ b/src/search/queries/params/rewrite.rs
@@ -3,7 +3,7 @@ use serde::ser::{Serialize, Serializer};
 /// Method used to rewrite the query.
 ///
 /// > **This parameter is for expert users only. Changing the value of this
-/// parameter can impact search performance and relevance.**
+/// > parameter can impact search performance and relevance.**
 ///
 /// The `rewrite` parameter determines:
 /// - How Lucene calculates the relevance scores for each matching document

--- a/src/search/queries/params/script_object.rs
+++ b/src/search/queries/params/script_object.rs
@@ -98,18 +98,18 @@ pub enum ScriptLang {
     /// Painless provides numerous capabilities that center around the following core principles:
     ///
     /// - **Safety**: Ensuring the security of your cluster is of utmost importance. To that end, Painless
-    /// uses a fine-grained allowlist with a granularity down to the members of a class. Anything
-    /// that is not part of the allowlist results in a compilation error. See the [Painless API
-    /// Reference](https://www.elastic.co/guide/en/elasticsearch/painless/7.15/painless-api-reference.html)
-    /// for a complete list of available classes, methods, and fields per script context.
+    ///   uses a fine-grained allowlist with a granularity down to the members of a class. Anything
+    ///   that is not part of the allowlist results in a compilation error. See the [Painless API
+    ///   Reference](https://www.elastic.co/guide/en/elasticsearch/painless/7.15/painless-api-reference.html)
+    ///   for a complete list of available classes, methods, and fields per script context.
     ///
     /// - **Performance**: Painless compiles directly into JVM bytecode to take advantage of all possible
-    /// optimizations that the JVM provides. Also, Painless typically avoids features that require
-    /// additional slower checks at runtime.
+    ///   optimizations that the JVM provides. Also, Painless typically avoids features that require
+    ///   additional slower checks at runtime.
     ///
     /// - **Simplicity**: Painless implements a syntax with a natural familiarity to anyone with some
-    /// basic coding experience. Painless uses a subset of Java syntax with some additional
-    /// improvements to enhance readability and remove boilerplate.
+    ///   basic coding experience. Painless uses a subset of Java syntax with some additional
+    ///   improvements to enhance readability and remove boilerplate.
     ///
     /// <https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting-painless.html>
     Painless,

--- a/src/search/queries/span/span_term_query.rs
+++ b/src/search/queries/span/span_term_query.rs
@@ -25,7 +25,7 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `value` - Term you wish to find in the provided field.
-    /// To return a document, the term must exactly match the field value, including whitespace and capitalization.
+    ///   To return a document, the term must exactly match the field value, including whitespace and capitalization.
     pub fn span_term<T, U>(field: T, value: U) -> SpanTermQuery
     where
         T: ToString,

--- a/src/search/queries/specialized/distance_feature_query.rs
+++ b/src/search/queries/specialized/distance_feature_query.rs
@@ -114,35 +114,35 @@ impl Query {
     ///
     /// - `field` - Name of the field used to calculate distances. This field must meet the following criteria:<br/>
     ///   - Be a [`date`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html),
-    /// [`date_nanos`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html) or
-    /// [`geo_point`](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html) field
+    ///     [`date_nanos`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html) or
+    ///     [`geo_point`](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html) field
     ///   - Have an [index](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-index.html)
-    /// mapping parameter value of `true`, which is the default
+    ///     mapping parameter value of `true`, which is the default
     ///   - Have an [`doc_values`](https://www.elastic.co/guide/en/elasticsearch/reference/current/doc-values.html)
-    /// mapping parameter value of `true`, which is the default
+    ///     mapping parameter value of `true`, which is the default
     /// - `origin` - Date or point of origin used to calculate distances.<br/>
-    /// If the `field` value is a
-    /// [`date`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html) or
-    /// [`date_nanos`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html)
-    /// field, the `origin` value must be a
-    /// [date](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-daterange-aggregation.html#date-format-pattern).
-    /// [Date Math](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math),
-    /// such as `now-1h`, is supported.<br/>
-    /// If the `field` value is a
-    /// [`geo_point`](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html)
-    /// field, the `origin` value must be a geopoint.
+    ///   If the `field` value is a
+    ///   [`date`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html) or
+    ///   [`date_nanos`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html)
+    ///   field, the `origin` value must be a
+    ///   [date](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-daterange-aggregation.html#date-format-pattern).
+    ///   [Date Math](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math),
+    ///   such as `now-1h`, is supported.<br/>
+    ///   If the `field` value is a
+    ///   [`geo_point`](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html)
+    ///   field, the `origin` value must be a geopoint.
     /// - `pivot` - Distance from the `origin` at which relevance scores receive half of the boost value.<br/>
-    /// If the field value is a
-    /// [`date`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html) or
-    /// [`date_nanos`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html)
-    /// field, the `pivot` value must be a
-    /// [`time unit`](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units)
-    /// , such as `1h` or `10d`.<br/>
-    /// If the `field` value is a
-    /// [`geo_point`](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html)
-    /// field, the `pivot` value must be a
-    /// [distance unit](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#distance-units)
-    /// , such as `1km` or `12m`.
+    ///   If the field value is a
+    ///   [`date`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html) or
+    ///   [`date_nanos`](https://www.elastic.co/guide/en/elasticsearch/reference/current/date_nanos.html)
+    ///   field, the `pivot` value must be a
+    ///   [`time unit`](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#time-units)
+    ///   , such as `1h` or `10d`.<br/>
+    ///   If the `field` value is a
+    ///   [`geo_point`](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html)
+    ///   field, the `pivot` value must be a
+    ///   [distance unit](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#distance-units)
+    ///   , such as `1km` or `12m`.
     pub fn distance_feature<T, O>(
         field: T,
         origin: O,

--- a/src/search/queries/specialized/knn_query.rs
+++ b/src/search/queries/specialized/knn_query.rs
@@ -9,8 +9,8 @@ use serde::Serialize;
 /// search request. _knn_ query is reserved for expert cases, where there is a need to combine this query with other queries.
 ///
 /// > `knn` query doesn’t have a separate `k` parameter. `k` is defined by `size` parameter of a search request
-/// similar to other queries. `knn` query collects `num_candidates` results from each shard, then merges them to get
-/// the top `size` results.
+/// > similar to other queries. `knn` query collects `num_candidates` results from each shard, then merges them to get
+/// > the top `size` results.
 ///
 /// To create a knn query:
 /// ```
@@ -85,7 +85,7 @@ impl Query {
     ///
     /// - `field` - The name of the vector field to search against. Must be a dense_vector field with indexing enabled.
     /// - `query_vector` - Query vector. Must have the same number of dimensions as the vector field you are searching
-    /// against.
+    ///   against.
     pub fn knn<T>(field: T, query_vector: Vec<f32>) -> KnnQuery
     where
         T: ToString,

--- a/src/search/queries/specialized/script_query.rs
+++ b/src/search/queries/specialized/script_query.rs
@@ -30,7 +30,7 @@ impl Query {
     /// Creates an instance of [`ScriptQuery`]
     ///
     /// - `script` - Contains a script to run as a query. This script must
-    /// return a boolean value, `true` or `false`
+    ///   return a boolean value, `true` or `false`
     pub fn script(script: Script) -> ScriptQuery {
         ScriptQuery {
             script,

--- a/src/search/queries/specialized/script_score_query.rs
+++ b/src/search/queries/specialized/script_score_query.rs
@@ -39,7 +39,7 @@ impl Query {
     ///
     /// - `query` - Query used to return documents
     /// - `script` - Script used to compute the score of documents returned by
-    /// the `query`
+    ///   the `query`
     pub fn script_score<Q>(query: Q, script: Script) -> ScriptScoreQuery
     where
         Q: Into<Query>,

--- a/src/search/queries/term_level/exists_query.rs
+++ b/src/search/queries/term_level/exists_query.rs
@@ -34,8 +34,8 @@ impl Query {
     /// Creates an instance of [`ExistsQuery`]
     ///
     /// - `field` - Name of the field you wish to search.
-    /// While a field is deemed non-existent if the JSON value is `null` or `[]`,
-    /// these values will indicate the field does exist:
+    ///   While a field is deemed non-existent if the JSON value is `null` or `[]`,
+    ///   these values will indicate the field does exist:
     ///   - Empty strings, such as `""` or `"-"`
     ///   - Arrays containing `null` and another value, such as `[null, "foo"]`
     ///   - A custom [`null-value`](https://www.elastic.co/guide/en/elasticsearch/reference/current/null-value.html), defined in field mapping

--- a/src/search/queries/term_level/fuzzy_query.rs
+++ b/src/search/queries/term_level/fuzzy_query.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 /// - Removing a character (**b**lack → lack)
 /// - Inserting a character (sic → sic**k**)
 /// - Transposing two adjacent characters (**ac**t → **ca**t)
-/// To find similar terms, the fuzzy query creates a set of all possible variations, or expansions, of the search term within a specified edit distance. The query then returns exact matches for each expansion.
+///   To find similar terms, the fuzzy query creates a set of all possible variations, or expansions, of the search term within a specified edit distance. The query then returns exact matches for each expansion.
 ///
 /// To create a fuzzy query with numeric values:
 /// ```

--- a/src/search/queries/term_level/ids_query.rs
+++ b/src/search/queries/term_level/ids_query.rs
@@ -31,7 +31,7 @@ impl Query {
     /// Creates an instance of [`IdsQuery`]
     ///
     /// - `values` - An array of
-    /// [document IDs](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html).
+    ///   [document IDs](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html).
     pub fn ids<I>(values: I) -> IdsQuery
     where
         I: IntoIterator,

--- a/src/search/queries/term_level/prefix_query.rs
+++ b/src/search/queries/term_level/prefix_query.rs
@@ -47,7 +47,7 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `value` - Term you wish to find in the provided field.
-    /// To return a document, the term must exactly match the field value, including whitespace and capitalization.
+    ///   To return a document, the term must exactly match the field value, including whitespace and capitalization.
     pub fn prefix<T, U>(field: T, value: U) -> PrefixQuery
     where
         T: ToString,

--- a/src/search/queries/term_level/range_query.rs
+++ b/src/search/queries/term_level/range_query.rs
@@ -120,8 +120,8 @@ impl RangeQuery {
     /// [`format`](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html).
     ///
     /// >If a format or date value is incomplete, the range query replaces
-    /// any missing components with default values. See
-    /// [Missing date components](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html#missing-date-components).
+    /// > any missing components with default values. See
+    /// > [Missing date components](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-range-query.html#missing-date-components).
     pub fn format<T>(mut self, format: T) -> Self
     where
         T: ToString,

--- a/src/search/queries/term_level/regexp_query.rs
+++ b/src/search/queries/term_level/regexp_query.rs
@@ -52,8 +52,8 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `value` - Regular expression for terms you wish to find in the provided field. For a list
-    /// of supported operators, see
-    /// [Regular expression syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/regexp-syntax.html). <br/>
+    ///   of supported operators, see
+    ///   [Regular expression syntax](https://www.elastic.co/guide/en/elasticsearch/reference/current/regexp-syntax.html). <br/>
     ///
     /// By default, regular expressions are limited to 1,000 characters. You can change this limit
     /// using the

--- a/src/search/queries/term_level/term_query.rs
+++ b/src/search/queries/term_level/term_query.rs
@@ -43,7 +43,7 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `value` - Term you wish to find in the provided field.
-    /// To return a document, the term must exactly match the field value, including whitespace and capitalization.
+    ///   To return a document, the term must exactly match the field value, including whitespace and capitalization.
     pub fn term<T, U>(field: T, value: U) -> TermQuery
     where
         T: ToString,

--- a/src/search/queries/term_level/terms_lookup_query.rs
+++ b/src/search/queries/term_level/terms_lookup_query.rs
@@ -11,9 +11,9 @@ use crate::util::*;
 /// field is enabled by default.
 ///
 /// > By default, Elasticsearch limits the `terms` query to a maximum of
-/// 65,536 terms. This includes terms fetched using terms lookup. You can
-/// change this limit using the
-/// [`index.max_terms_count setting`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-terms-count).
+/// > 65,536 terms. This includes terms fetched using terms lookup. You can
+/// > change this limit using the
+/// > [`index.max_terms_count setting`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-terms-count).
 ///
 /// To create a terms lookup query:
 /// ```
@@ -57,11 +57,11 @@ impl Query {
     /// - `field` - Field you wish to search.
     /// - `index` - Name of the index from which to fetch field values.
     /// - `id` - [ID](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-id-field.html)
-    /// of the document from which to fetch field values.
+    ///   of the document from which to fetch field values.
     /// - `path` - Name of the field from which to fetch field values. Elasticsearch uses
-    /// these values as search terms for the query. If the field values
-    /// include an array of nested inner objects, you can access those objects
-    /// using dot notation syntax.
+    ///   these values as search terms for the query. If the field values
+    ///   include an array of nested inner objects, you can access those objects
+    ///   using dot notation syntax.
     pub fn terms_lookup<S, T, U, V>(field: S, index: T, id: U, path: V) -> TermsLookupQuery
     where
         S: ToString,

--- a/src/search/queries/term_level/terms_query.rs
+++ b/src/search/queries/term_level/terms_query.rs
@@ -42,13 +42,13 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `values` - An array of terms you wish to find in the provided field. To return a
-    /// document, one or more terms must exactly match a field value,
-    /// including whitespace and capitalization.<br/>
-    /// By default, Elasticsearch limits the `terms` query to a maximum of
-    /// 65,536 terms. You can change this limit using the
-    /// [`index.max_terms_count setting`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-terms-count).<br/>
+    ///   document, one or more terms must exactly match a field value,
+    ///   including whitespace and capitalization.<br/>
+    ///   By default, Elasticsearch limits the `terms` query to a maximum of
+    ///   65,536 terms. You can change this limit using the
+    ///   [`index.max_terms_count setting`](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-modules.html#index-max-terms-count).<br/>
     /// > To use the field values of an existing document as search terms,
-    /// use the terms lookup parameters.
+    /// > use the terms lookup parameters.
     pub fn terms<S, I>(field: S, terms: I) -> TermsQuery
     where
         S: ToString,

--- a/src/search/queries/term_level/terms_set_query.rs
+++ b/src/search/queries/term_level/terms_set_query.rs
@@ -50,7 +50,7 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `value` - TermsSet you wish to find in the provided field.
-    /// To return a document, the terms_set must exactly match the field value, including whitespace and capitalization.
+    ///   To return a document, the terms_set must exactly match the field value, including whitespace and capitalization.
     pub fn terms_set<S, T, U>(field: S, terms: T, minimum_should_match: U) -> TermsSetQuery
     where
         S: ToString,

--- a/src/search/queries/term_level/wildcard_query.rs
+++ b/src/search/queries/term_level/wildcard_query.rs
@@ -42,7 +42,7 @@ impl Query {
     ///
     /// - `field` - Field you wish to search.
     /// - `value` - Wildcard you wish to find in the provided field.
-    /// To return a document, the wildcard must exactly match the field value, including whitespace and capitalization.
+    ///   To return a document, the wildcard must exactly match the field value, including whitespace and capitalization.
     pub fn wildcard<T, U>(field: T, value: U) -> WildcardQuery
     where
         T: ToString,


### PR DESCRIPTION
Rust 1.80 introduced a new clippy lint which requires fixing this codebase.