### PR TITLE
dependabot: update serde dependencies in group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      serde:
+        patterns:
+          - 'serde*'


### PR DESCRIPTION
I would like to avoid updating serde and serde_json in separate pull requests, let's ask dependabot to group them.