### PR TITLE
Implement sorting within nested objects

### DIFF
--- a/src/search/sort/mod.rs
+++ b/src/search/sort/mod.rs
@@ -6,6 +6,7 @@
 
 mod field_sort;
 mod geo_distance_sort;
+mod nested_field_sort;
 mod script_sort;
 mod sort_;
 mod sort_collection;
@@ -16,6 +17,7 @@ mod sort_special_field;
 
 pub use self::field_sort::*;
 pub use self::geo_distance_sort::*;
+pub use self::nested_field_sort::*;
 pub use self::script_sort::*;
 pub use self::sort_::*;
 pub use self::sort_collection::*;

--- a/src/search/sort/nested_field_sort.rs
+++ b/src/search/sort/nested_field_sort.rs
@@ -1,0 +1,103 @@
+use crate::{util::ShouldSkip, Query};
+
+/// Sorts search hits by fields that are inside one or more nested objects.
+///
+/// <https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#nested-sorting>
+#[derive(Default, Clone, PartialEq, Debug, Serialize)]
+pub struct NestedFieldSort {
+    path: String,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    filter: Option<Query>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    max_children: Option<u32>,
+
+    #[serde(skip_serializing_if = "ShouldSkip::should_skip")]
+    nested: Option<Box<NestedFieldSort>>,
+}
+
+impl NestedFieldSort {
+    /// Creates an instance of [NestedFieldSort]
+    pub fn path<T>(path: T) -> Self
+    where
+        T: ToString,
+    {
+        Self {
+            path: path.to_string(),
+            filter: None,
+            max_children: None,
+            nested: None,
+        }
+    }
+
+    /// A filter that the inner objects inside the nested path should match with in order for its field values to be taken into account by sorting.
+    pub fn filter<T>(mut self, filter: T) -> Self
+    where
+        T: Into<Option<Query>>,
+    {
+        self.filter = filter.into();
+        self
+    }
+
+    /// The maximum number of children to consider per root document when picking the sort value.
+    pub fn max_children(mut self, max_children: u32) -> Self {
+        self.max_children = Some(max_children);
+        self
+    }
+
+    /// Same as top-level nested but applies to another nested path within the current nested object.
+    pub fn nested(mut self, nested: NestedFieldSort) -> Self {
+        self.nested = Some(Box::new(nested));
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{util::assert_serialize, Query};
+
+    #[test]
+    fn serialization() {
+        // custom tests
+        assert_serialize(NestedFieldSort::path("offer"), json!({  "path": "offer" }));
+
+        assert_serialize(
+            NestedFieldSort::path("offer").max_children(2),
+            json!({  "path": "offer", "max_children": 2 }),
+        );
+
+        // based on examples from Elasticsearch documentation
+        assert_serialize(
+            NestedFieldSort::path("offer").filter(Query::term("offer.color", "blue")),
+            json!({
+               "path": "offer",
+               "filter": {
+                  "term" : { "offer.color" : {"value": "blue"} }
+               }
+            }),
+        );
+
+        assert_serialize(
+            NestedFieldSort::path("parent")
+                .filter(Query::range("parent.age").gte(21))
+                .nested(
+                    NestedFieldSort::path("parent.child")
+                        .filter(Query::r#match("parent.child.name", "matt")),
+                ),
+            json!({
+                "path": "parent",
+                "filter": {
+                   "range": {"parent.age": {"gte": 21}}
+                },
+                "nested": {
+                   "path": "parent.child",
+                   "filter": {
+                      "match": {"parent.child.name": {"query": "matt"}}
+                   }
+                }
+            }),
+        );
+    }
+}


### PR DESCRIPTION
Adds support for sorting within nested objects, as per:

https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#nested-sorting

The syntax looks like this:

```rust
    Sort::FieldSort(
        FieldSort::descending("applications.date").nested(NestedFieldSort::path("applications")),
    )
```

Further examples can be found in the tests within the commit. Please let me know if you are unhappy with the API/syntax and I'm happy to make changes. Thank you!