### PR TITLE
chore: allow large enum variants

### DIFF
--- a/src/search/sort/sort_.rs
+++ b/src/search/sort/sort_.rs
@@ -4,6 +4,7 @@ use std::borrow::Cow;
 /// Sorting criterion
 #[derive(Clone, PartialEq, Serialize)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum Sort {
     /// Special sort field,
     SpecialField(SortSpecialField),


### PR DESCRIPTION
Not a large issue in this case, usually payloads are smaller and I prefer not to break the current behavior.